### PR TITLE
If gdbm is not available, fall back to anydbm.

### DIFF
--- a/warcprox/warcprox.py
+++ b/warcprox/warcprox.py
@@ -44,8 +44,12 @@ try:
     import dbm.gnu
     dbm_gnu = dbm.gnu
 except ImportError:
-    import gdbm
-    dbm_gnu = gdbm
+    try:
+        import gdbm
+        dbm_gnu = gdbm
+    except ImportError:
+        import anydbm
+        dbm_gnu = anydbm
 
 try:
     from io import StringIO


### PR DESCRIPTION
gdbm isn't available in the built in Python 2.7.5 on Mac OS 10.9.1. Falling back to anydbm seems to work, although I don't know what the differences might be.
