### PR TITLE
check if 'sync' method exists before calling it

### DIFF
--- a/warcprox/warcprox.py
+++ b/warcprox/warcprox.py
@@ -689,7 +689,8 @@ class DedupDb(object):
         self.db.close()
 
     def sync(self):
-        self.db.sync()
+        if hasattr(self.db, 'sync'):
+            self.db.sync()
 
     def save(self, key, response_record, offset):
         record_id = response_record.get_header(warctools.WarcRecord.ID).decode('latin1')
@@ -999,7 +1000,8 @@ class PlaybackIndexDb(object):
 
 
     def sync(self):
-        self.db.sync()
+        if hasattr(self.db, 'sync'):
+            self.db.sync()
 
 
     def save(self, warcfile, recordset, offset):


### PR DESCRIPTION
It turns out that anydbm does not have a public sync() method, per the docs: https://docs.python.org/2/library/anydbm.html
On ubuntu, there is one, but on OS X, there isn't, so adding a check to see if actually exists before calling it.
Found in ikreymer/pywb-webrecorder#4
