### PR TITLE
Record segmentation and rollover by size

### DIFF
--- a/warcprox/controller.py
+++ b/warcprox/controller.py
@@ -35,7 +35,7 @@ class WarcproxController(object):
             self.warc_writer_thread = warcprox.warcwriter.WarcWriterThread(recorded_url_q=self.proxy.recorded_url_q)
 
         self.playback_proxy = playback_proxy
-
+        self.stop = None
 
     def run_until_shutdown(self):
         """Start warcprox and run until shut down.
@@ -43,6 +43,7 @@ class WarcproxController(object):
         If running in the main thread, SIGTERM initiates a graceful shutdown.
         Otherwise, call warcprox_controller.stop.set().
         """
+        self.logger.info("Running until shutdown")
         proxy_thread = threading.Thread(target=self.proxy.serve_forever, name='ProxyThread')
         proxy_thread.start()
         self.warc_writer_thread.start()
@@ -54,9 +55,10 @@ class WarcproxController(object):
         self.stop = threading.Event()
 
         try:
-            signal.signal(signal.SIGTERM, self.stop.set)
+            signal.signal(signal.SIGTERM, lambda signal_number, stack_frame: self.stop.set())
             self.logger.info('SIGTERM will initiate graceful shutdown')
         except ValueError:
+            self.logger.info('SIGTERM will NOT initiate graceful shutdown')
             pass
 
         try:
@@ -66,6 +68,7 @@ class WarcproxController(object):
             pass
         finally:
             self.warc_writer_thread.stop.set()
+            self.proxy.stop.set()
             self.proxy.shutdown()
             self.proxy.server_close()
 

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -46,9 +46,16 @@ def _build_arg_parser(prog=os.path.basename(sys.argv[0])):
     arg_parser.add_argument('-s', '--size', dest='size',
             default=1000*1000*1000,
             help='WARC file rollover size threshold in bytes')
+    arg_parser.add_argument('-r', '--record-size', dest='record_size',
+            default=1000*1000*100,
+            help='WARC record rollover size threshold in bytes')
     arg_parser.add_argument('--rollover-idle-time',
             dest='rollover_idle_time', default=None,
             help="WARC file rollover idle time threshold in seconds (so that Friday's last open WARC doesn't sit there all weekend waiting for more data)")
+    arg_parser.add_argument('--record-rollover-time',
+            dest='record_rollover_time', default=None,
+            help="WARC record rollover time threshold in seconds to automatically use a new WARC after a period of time")
+
     try:
         hash_algos = hashlib.algorithms_guaranteed
     except AttributeError:
@@ -111,7 +118,9 @@ def main(argv=sys.argv):
     proxy = warcprox.warcprox.WarcProxy(
             server_address=(args.address, int(args.port)), ca=ca,
             recorded_url_q=recorded_url_q,
-            digest_algorithm=args.digest_algorithm)
+            digest_algorithm=args.digest_algorithm,
+            record_size=int(args.record_size),
+            record_rollover_time=int(args.record_rollover_time) if args.record_rollover_time is not None else None)
 
     if args.playback_port is not None:
         playback_index_db = warcprox.playback.PlaybackIndexDb(args.playback_index_db_file)

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -52,6 +52,9 @@ def _build_arg_parser(prog=os.path.basename(sys.argv[0])):
     arg_parser.add_argument('--rollover-idle-time',
             dest='rollover_idle_time', default=None,
             help="WARC file rollover idle time threshold in seconds (so that Friday's last open WARC doesn't sit there all weekend waiting for more data)")
+    arg_parser.add_argument('--rollover-time',
+            dest='rollover_time', default=None,
+            help="WARC file rollover time threshold in seconds to automatically use a new WARC after a period of time")
     arg_parser.add_argument('--record-rollover-time',
             dest='record_rollover_time', default=None,
             help="WARC record rollover time threshold in seconds to automatically use a new WARC after a period of time")
@@ -136,7 +139,8 @@ def main(argv=sys.argv):
             gzip=args.gzip, prefix=args.prefix, port=int(args.port),
             rollover_size=int(args.size), base32=args.base32,
             dedup_db=dedup_db, digest_algorithm=args.digest_algorithm,
-            playback_index_db=playback_index_db)
+            playback_index_db=playback_index_db,
+            rollover_time=int(args.rollover_time) if args.rollover_time is not None else None)
     warc_writer_thread = warcprox.warcwriter.WarcWriterThread(
             recorded_url_q=recorded_url_q, warc_writer=warc_writer,
             rollover_idle_time=int(args.rollover_idle_time) if args.rollover_idle_time is not None else None)

--- a/warcprox/warcprox.py
+++ b/warcprox/warcprox.py
@@ -36,6 +36,8 @@ import traceback
 import hashlib
 import json
 import socket
+import threading
+import time
 
 from certauth.certauth import CertificateAuthority
 import warcprox.mitmproxy
@@ -48,7 +50,7 @@ class ProxyingRecorder(object):
 
     logger = logging.getLogger("warcprox.warcprox.ProxyingRecorder")
 
-    def __init__(self, fp, proxy_dest, digest_algorithm='sha1'):
+    def __init__(self, fp, proxy_dest, digest_algorithm='sha1', prev_continuation_payload_size=0):
         self.fp = fp
         # "The file has no name, and will cease to exist when it is closed."
         self.tempfile = tempfile.SpooledTemporaryFile(max_size=512*1024)
@@ -60,6 +62,7 @@ class ProxyingRecorder(object):
         self._proxy_dest_conn_open = True
         self._prev_hunk_last_two_bytes = b''
         self.len = 0
+        self.prev_continuation_payload_size = prev_continuation_payload_size
 
     def _update_payload_digest(self, hunk):
         if self.payload_digest is None:
@@ -137,15 +140,21 @@ class ProxyingRecorder(object):
         else:
             return 0
 
+    def continuation_payload_size(self):
+        return self.prev_continuation_payload_size + self.payload_size()
+
 
 class ProxyingRecordingHTTPResponse(http_client.HTTPResponse):
 
     def __init__(self, sock, debuglevel=0, method=None, proxy_dest=None, digest_algorithm='sha1'):
         http_client.HTTPResponse.__init__(self, sock, debuglevel=debuglevel, method=method)
 
+        self.proxy_dest = proxy_dest
+        self.digest_algorithm = digest_algorithm
+        self.orig_fp = self.fp
         # Keep around extra reference to self.fp because HTTPResponse sets
         # self.fp=None after it finishes reading, but we still need it
-        self.recorder = ProxyingRecorder(self.fp, proxy_dest, digest_algorithm)
+        self.recorder = ProxyingRecorder(self.orig_fp, self.proxy_dest, self.digest_algorithm)
         self.fp = self.recorder
 
 
@@ -196,26 +205,65 @@ class WarcProxyHandler(warcprox.mitmproxy.MitmProxyHandler):
                 digest_algorithm=self.server.digest_algorithm)
         h.begin()
 
+        remote_ip = self._proxy_sock.getpeername()[0]
+
         buf = h.read(8192)
+        # Keep track of which segment is the first segment, since WARC
+        # continuation records need WARC-Segment-Origin-ID header field.
+        first_segment = None
+        # Keep track of segment number, since WARC continuation records
+        # need WARC-Segment-Number header field.
+        segment_number = 0
+        # Keep track of start time so that can rollover WARC record based on time.
+        record_start_time = time.time()
         while buf != b'':
+            # Check if should interrupt reading the response.
+            if self.server.stop.is_set():
+                self.logger.debug("Interrupting stream since stop is set")
+                break
+            # Read a chunk from the response.
             buf = h.read(8192)
+            self.logger.debug("Record size: %s. Max is %s.", h.recorder.len, self.server.record_size)
+            # If record has gotten too big or taken too long, segment it.
+            if (self.server.record_size and h.recorder.len > self.server.record_size) \
+                    or (self.server.record_rollover_time
+                        and time.time() - record_start_time > self.server.record_rollover_time):
+                self.logger.info("Starting a new record")
+                segment_number += 1
+                # Create a RecordedUrl and add it to the queue to be written to WARC.
+                recorded_url = RecordedUrl(url=self.url, request_data=req,
+                    response_recorder=h.recorder, remote_ip=remote_ip,
+                    warcprox_meta=warcprox_meta, first_segment=first_segment, segment_number=segment_number)
+                self.server.recorded_url_q.put(recorded_url)
+                # Update information that will be needed for later segments.
+                if not first_segment:
+                    first_segment = recorded_url
+                prev_continuation_payload_size = h.recorder.continuation_payload_size()
+                # Reset things.
+                # Provide ProxyingRecordingHTTPResponse with a fresh ProxyingRecorder
+                h.recorder = ProxyingRecorder(h.orig_fp, h.proxy_dest, h.digest_algorithm,
+                                              prev_continuation_payload_size=prev_continuation_payload_size)
+                h.fp = h.recorder
+                record_start_time = time.time()
 
         self.log_request(h.status, h.recorder.len)
-
-        remote_ip = self._proxy_sock.getpeername()[0]
 
         # Let's close off the remote end
         h.close()
         self._proxy_sock.close()
 
+        if first_segment:
+            segment_number += 1
         recorded_url = RecordedUrl(url=self.url, request_data=req,
                 response_recorder=h.recorder, remote_ip=remote_ip,
-                warcprox_meta=warcprox_meta)
+                warcprox_meta=warcprox_meta, first_segment=first_segment, is_last_segment=True,
+                segment_number=segment_number, truncated=(first_segment and self.server.stop.is_set()))
         self.server.recorded_url_q.put(recorded_url)
 
 
 class RecordedUrl(object):
-    def __init__(self, url, request_data, response_recorder, remote_ip, warcprox_meta=None):
+    def __init__(self, url, request_data, response_recorder, remote_ip, warcprox_meta=None, first_segment=None,
+                 is_last_segment=False, segment_number=0, truncated=False):
         # XXX should test what happens with non-ascii url (when does
         # url-encoding happen?)
         if type(url) is not bytes:
@@ -236,16 +284,30 @@ class RecordedUrl(object):
         else:
             self.warcprox_meta = {}
 
+        self.first_segment = first_segment
+        self.is_last_segment = is_last_segment
+        self.segment_number = segment_number
+        self.truncated = truncated
+
 
 class WarcProxy(socketserver.ThreadingMixIn, http_server.HTTPServer):
     logger = logging.getLogger("warcprox.warcprox.WarcProxy")
 
     def __init__(self, server_address=('localhost', 8000),
             req_handler_class=WarcProxyHandler, bind_and_activate=True,
-            ca=None, recorded_url_q=None, digest_algorithm='sha1'):
+            ca=None, recorded_url_q=None, digest_algorithm='sha1', record_size=1000 * 1000 * 100,
+            record_rollover_time=5 * 60):
         http_server.HTTPServer.__init__(self, server_address, req_handler_class, bind_and_activate)
 
+        #This will be used to tell the WarcProxyHandler to interrupt.
+        self.stop = threading.Event()
+
         self.digest_algorithm = digest_algorithm
+        self.record_size  = record_size
+        self.record_rollover_time= record_rollover_time
+        #This causes abrupt termination
+        #However, we don't want to end abruptly since need to write final segment record.
+        # self.daemon_threads = True
 
         if ca is not None:
             self.ca = ca

--- a/warcprox/warcwriter.py
+++ b/warcprox/warcwriter.py
@@ -46,9 +46,13 @@ class WarcWriter:
         self._fpath = None
         self._serial = 0
 
+        #Map of the the record_url of the first segment of a map to the record id it was assigned.
+        self.continuation_map = {}
+
         if not os.path.exists(directory):
             self.logger.info("warc destination directory {} doesn't exist, creating it".format(directory))
             os.mkdir(directory)
+
 
 
     # returns a tuple (principal_record, request_record) where principal_record is either a response or revisit record
@@ -79,6 +83,41 @@ class WarcWriter:
                     profile=warctools.WarcRecord.PROFILE_IDENTICAL_PAYLOAD_DIGEST,
                     content_type=hanzo.httptools.ResponseMessage.CONTENT_TYPE,
                     remote_ip=recorded_url.remote_ip)
+
+        elif recorded_url.segment_number == 1:
+            self.logger.info("Writing first segment record")
+            #First segment
+            principal_record = self.build_warc_record(
+                    url=recorded_url.url, warc_date=warc_date,
+                    recorder=recorded_url.response_recorder,
+                    warc_type=warctools.WarcRecord.RESPONSE,
+                    content_type=hanzo.httptools.ResponseMessage.CONTENT_TYPE,
+                    remote_ip=recorded_url.remote_ip,
+                    segment_number=recorded_url.segment_number)
+            self.continuation_map[recorded_url] = principal_record.id
+        elif recorded_url.segment_number and recorded_url.is_last_segment:
+            self.logger.info("Writing last segment record")
+            #Last segment
+            principal_record = self.build_warc_record(
+                    url=recorded_url.url, warc_date=warc_date,
+                    recorder=recorded_url.response_recorder,
+                    warc_type="continuation",
+                    content_type=hanzo.httptools.ResponseMessage.CONTENT_TYPE,
+                    remote_ip=recorded_url.remote_ip, segment_number=recorded_url.segment_number,
+                    segment_origin=self.continuation_map[recorded_url.first_segment],
+                    segment_total_length=recorded_url.response_recorder.continuation_payload_size(),
+                    truncated = recorded_url.truncated)
+        elif recorded_url.segment_number:
+            self.logger.info("Writing %s segment record", recorded_url.segment_number)
+            #Middle segment
+            principal_record = self.build_warc_record(
+                    url=recorded_url.url, warc_date=warc_date,
+                    recorder=recorded_url.response_recorder,
+                    warc_type="continuation",
+                    content_type=hanzo.httptools.ResponseMessage.CONTENT_TYPE,
+                    remote_ip=recorded_url.remote_ip, segment_number=recorded_url.segment_number,
+                    segment_origin=self.continuation_map[recorded_url.first_segment],
+                    truncated = recorded_url.truncated)
         else:
             # response record
             principal_record = self.build_warc_record(
@@ -88,12 +127,15 @@ class WarcWriter:
                     content_type=hanzo.httptools.ResponseMessage.CONTENT_TYPE,
                     remote_ip=recorded_url.remote_ip)
 
-        request_record = self.build_warc_record(
-                url=recorded_url.url, warc_date=warc_date,
-                data=recorded_url.request_data,
-                warc_type=warctools.WarcRecord.REQUEST,
-                content_type=hanzo.httptools.RequestMessage.CONTENT_TYPE,
-                concurrent_to=principal_record.id)
+        #Don't write if a continuation record > 1
+        request_record = None
+        if recorded_url.segment_number <= 1:
+            request_record = self.build_warc_record(
+                    url=recorded_url.url, warc_date=warc_date,
+                    data=recorded_url.request_data,
+                    warc_type=warctools.WarcRecord.REQUEST,
+                    content_type=hanzo.httptools.RequestMessage.CONTENT_TYPE,
+                    concurrent_to=principal_record.id)
 
         return principal_record, request_record
 
@@ -105,7 +147,8 @@ class WarcWriter:
     def build_warc_record(self, url, warc_date=None, recorder=None, data=None,
         concurrent_to=None, warc_type=None, content_type=None, remote_ip=None,
         profile=None, refers_to=None, refers_to_target_uri=None,
-        refers_to_date=None, payload_digest=None):
+        refers_to_date=None, payload_digest=None, segment_number=0, segment_origin=None, segment_total_length=0,
+        truncated=False):
 
         if warc_date is None:
             warc_date = warctools.warc.warc_datetime_str(datetime.utcnow())
@@ -134,6 +177,14 @@ class WarcWriter:
             headers.append((warctools.WarcRecord.CONTENT_TYPE, content_type))
         if payload_digest is not None:
             headers.append((warctools.WarcRecord.PAYLOAD_DIGEST, payload_digest))
+        if segment_number:
+            headers.append(("WARC-Segment-Number", str(segment_number).encode(('latin1'))))
+        if segment_origin is not None:
+            headers.append(("WARC-Segment-Origin-ID", segment_origin))
+        if segment_total_length:
+            headers.append(("WARC-Segment-Total-Length", str(segment_total_length).encode('latin1')))
+        if truncated:
+            headers.append(("WARC-Truncated", "unspecified"))
 
         if recorder is not None:
             headers.append((warctools.WarcRecord.CONTENT_LENGTH, str(len(recorder)).encode('latin1')))
@@ -200,10 +251,13 @@ class WarcWriter:
 
     # <!-- <property name="template" value="${prefix}-${timestamp17}-${serialno}-${heritrix.pid}~${heritrix.hostname}~${heritrix.port}" /> -->
     def _writer(self):
+        #Rollover based on size
         if self._fpath and os.path.getsize(self._fpath) > self.rollover_size:
+            self.logger.debug("Closing WARC because exceeded rollover size.")
             self.close_writer()
 
         if self._f == None:
+            self._current_rollover_time = datetime.utcnow()
             self._f_finalname = '{}-{}-{:05d}-{}-{}-{}.warc{}'.format(
                     self.prefix, self.timestamp17(), self._serial, os.getpid(),
                     socket.gethostname(), self.port, '.gz' if self.gzip else '')
@@ -239,13 +293,14 @@ class WarcWriter:
         recordset_offset = writer.tell()
 
         for record in recordset:
-            offset = writer.tell()
-            record.write_to(writer, gzip=self.gzip)
-            self.logger.debug('wrote warc record: warc_type={} content_length={} url={} warc={} offset={}'.format(
-                    record.get_header(warctools.WarcRecord.TYPE),
-                    record.get_header(warctools.WarcRecord.CONTENT_LENGTH),
-                    record.get_header(warctools.WarcRecord.URL),
-                    self._fpath, offset))
+            if record:
+                offset = writer.tell()
+                record.write_to(writer, gzip=self.gzip)
+                self.logger.debug('wrote warc record: warc_type={} content_length={} url={} warc={} offset={}'.format(
+                        record.get_header(warctools.WarcRecord.TYPE),
+                        record.get_header(warctools.WarcRecord.CONTENT_LENGTH),
+                        record.get_header(warctools.WarcRecord.URL),
+                        self._fpath, offset))
 
         self._f.flush()
 
@@ -268,7 +323,7 @@ class WarcWriterThread(threading.Thread):
             self.warc_writer = WarcWriter()
 
     def run(self):
-        self.logger.info('WarcWriterThread starting, directory={} gzip={} rollover_size={} rollover_idle_time={} prefix={} port={}'.format(
+        self.logger.info('WarcWriterThread starting, directory={} gzip={} rollover_size={} rollover_idle_time={} prefix={} port={} rollover_time={}'.format(
                 os.path.abspath(self.warc_writer.directory), self.warc_writer.gzip, self.warc_writer.rollover_size,
                 self.rollover_idle_time, self.warc_writer.prefix, self.warc_writer.port))
 

--- a/warcprox/warcwriter.py
+++ b/warcprox/warcwriter.py
@@ -14,7 +14,7 @@ import hashlib
 import time
 import socket
 import base64
-from datetime import datetime
+from datetime import datetime, timedelta
 import hanzo.httptools
 from hanzo import warctools
 import warcprox
@@ -26,9 +26,10 @@ class WarcWriter:
     def __init__(self, directory='./warcs', rollover_size=1000000000,
             gzip=False, prefix='WARCPROX', port=0,
             digest_algorithm='sha1', base32=False, dedup_db=None,
-            playback_index_db=None):
+            playback_index_db=None, rollover_time=None):
 
         self.rollover_size = rollover_size
+        self.rollover_time = rollover_time
 
         self.gzip = gzip
         self.digest_algorithm = digest_algorithm
@@ -45,6 +46,7 @@ class WarcWriter:
         self._f = None
         self._fpath = None
         self._serial = 0
+        self._current_rollover_time = None
 
         #Map of the the record_url of the first segment of a map to the record id it was assigned.
         self.continuation_map = {}
@@ -209,9 +211,8 @@ class WarcWriter:
         return record
 
 
-    def timestamp17(self):
-        now = datetime.utcnow()
-        return '{:%Y%m%d%H%M%S}{:03d}'.format(now, now.microsecond//1000)
+    def timestamp17(self, when):
+        return '{:%Y%m%d%H%M%S}{:03d}'.format(when, when.microsecond//1000)
 
     def close_writer(self):
         if self._fpath:
@@ -222,6 +223,7 @@ class WarcWriter:
 
             self._fpath = None
             self._f = None
+            self._current_rollover_time = None
 
     def _build_warcinfo_record(self, filename):
         warc_record_date = warctools.warc.warc_datetime_str(datetime.utcnow())
@@ -251,6 +253,12 @@ class WarcWriter:
 
     # <!-- <property name="template" value="${prefix}-${timestamp17}-${serialno}-${heritrix.pid}~${heritrix.hostname}~${heritrix.port}" /> -->
     def _writer(self):
+        #Rollover based on time
+        if self._fpath and self.rollover_time \
+                and datetime.utcnow() - self._current_rollover_time > timedelta(seconds=self.rollover_time):
+            self.logger.debug("Closing WARC because exceeded rollover time.")
+            self.close_writer()
+
         #Rollover based on size
         if self._fpath and os.path.getsize(self._fpath) > self.rollover_size:
             self.logger.debug("Closing WARC because exceeded rollover size.")
@@ -259,7 +267,7 @@ class WarcWriter:
         if self._f == None:
             self._current_rollover_time = datetime.utcnow()
             self._f_finalname = '{}-{}-{:05d}-{}-{}-{}.warc{}'.format(
-                    self.prefix, self.timestamp17(), self._serial, os.getpid(),
+                    self.prefix, self.timestamp17(self._current_rollover_time), self._serial, os.getpid(),
                     socket.gethostname(), self.port, '.gz' if self.gzip else '')
             self._fpath = os.path.sep.join([self.directory, self._f_finalname + '.open'])
 
@@ -325,7 +333,7 @@ class WarcWriterThread(threading.Thread):
     def run(self):
         self.logger.info('WarcWriterThread starting, directory={} gzip={} rollover_size={} rollover_idle_time={} prefix={} port={} rollover_time={}'.format(
                 os.path.abspath(self.warc_writer.directory), self.warc_writer.gzip, self.warc_writer.rollover_size,
-                self.rollover_idle_time, self.warc_writer.prefix, self.warc_writer.port))
+                self.rollover_idle_time, self.warc_writer.prefix, self.warc_writer.port, self.warc_writer.rollover_time))
 
         self._last_sync = self._last_activity = time.time()
 


### PR DESCRIPTION
Add support for:
* Splitting long http responses into multiple WARC records using record segmentation. The size of each record is configurable with --record-size.
* Rollover of WARCs by time. The duration of each file is configurable with --rollover-time.

The motivation for these enhancements is to support recording of the [Twitter Streaming
API](https://dev.twitter.com/streaming/overview).