### PR TITLE
Return recorded_url from _proxy_request.

### DIFF
--- a/warcprox/warcprox.py
+++ b/warcprox/warcprox.py
@@ -213,6 +213,8 @@ class WarcProxyHandler(warcprox.mitmproxy.MitmProxyHandler):
                 warcprox_meta=warcprox_meta)
         self.server.recorded_url_q.put(recorded_url)
 
+        return recorded_url
+
 
 class RecordedUrl(object):
     def __init__(self, url, request_data, response_recorder, remote_ip, warcprox_meta=None):


### PR DESCRIPTION
Returning the RecordedUrl from _proxy_request allows subclasses to do things based on successful recording. For example, "visit URL; wait until a non-redirect status is recorded; then continue."

I also tried doing this by examining self.server.recorded_url_q, but then you're in a race with the intended consumers of the queue.