### PR TITLE
add --method-filter option

### DIFF
--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -77,6 +77,8 @@ def _build_arg_parser(prog=os.path.basename(sys.argv[0])):
             default='sha1', help='digest algorithm, one of {}'.format(', '.join(hash_algos)))
     arg_parser.add_argument('--base32', dest='base32', action='store_true',
             default=False, help='write digests in Base32 instead of hex')
+    arg_parser.add_argument('--method-filter', metavar='HTTP_METHOD',
+                            action='append', help='only record requests with the given http method(s) (can be used more than once)')
     arg_parser.add_argument('--stats-db-file', dest='stats_db_file',
             default='./warcprox-stats.db', help='persistent statistics database file; empty string or /dev/null disables statistics tracking')
     arg_parser.add_argument('-P', '--playback-port', dest='playback_port',

--- a/warcprox/writerthread.py
+++ b/warcprox/writerthread.py
@@ -56,12 +56,16 @@ class WarcWriterThread(threading.Thread):
         self.listeners = listeners
         self.options = options
         self.idle = None
+        self.method_filter = set(method.upper() for method in self.options.method_filter or [])
 
     def run(self):
         if self.options.profile:
             cProfile.runctx('self._run()', globals(), locals(), sort='cumulative')
         else:
             self._run()
+
+    def _filter_accepts(self, recorded_url):
+        return not self.method_filter or recorded_url.method.upper() in self.method_filter
 
     def _run(self):
         while not self.stop.is_set():
@@ -76,11 +80,12 @@ class WarcWriterThread(threading.Thread):
 
                         recorded_url = self.recorded_url_q.get(block=True, timeout=0.5)
                         self.idle = None
-                        if self.dedup_db:
-                            warcprox.dedup.decorate_with_dedup_info(self.dedup_db,
-                                    recorded_url, base32=self.options.base32)
-                        records = self.writer_pool.write_records(recorded_url)
-                        self._final_tasks(recorded_url, records)
+                        if self._filter_accepts(recorded_url):
+                            if self.dedup_db:
+                                warcprox.dedup.decorate_with_dedup_info(self.dedup_db,
+                                        recorded_url, base32=self.options.base32)
+                            records = self.writer_pool.write_records(recorded_url)
+                            self._final_tasks(recorded_url, records)
 
                         # try to release resources in a timely fashion
                         if recorded_url.response_recorder and recorded_url.response_recorder.tempfile:


### PR DESCRIPTION
Whitelist of methods to write WARC entries for. The final_tasks (logging, rethinkdb, kafka etc) are also skipped if a method is excluded.

Motivation: Many current tools that work with WARC files (pywb, openwayback etc) don't expect them to contain anything but GET requests as that's all Heritrix typically generates. Warcprox commonly records HEAD responses which means on replay it's pot luck as to whether you get content or an empty payload because the replay tool tried to replay the empty payload from the HEAD response.

While in the long term it'd be best to fix replay tools so they cope with non-GET methods in WARCs it's going to take some time for that to happen as it will require rethinking the way CDX indexing etc works as the response record by itself doesn't include the method. In the interim an option to filter the written responses by http method.would allow warcprox to be integrated immediately into existing web archiving pipelines with minimal changes.