### PR TITLE
allow zero warc_writer_threads

### DIFF
--- a/warcprox/controller.py
+++ b/warcprox/controller.py
@@ -176,7 +176,7 @@ class WarcproxController(object):
             assert(all(
                 wwt.dedup_db is self.warc_writer_threads[0].dedup_db
                 for wwt in self.warc_writer_threads))
-            if self.warc_writer_threads[0].dedup_db:
+            if any((t.dedup_db for t in self.warc_writer_threads)):
                 self.warc_writer_threads[0].dedup_db.start()
 
             for wwt in self.warc_writer_threads:
@@ -211,7 +211,7 @@ class WarcproxController(object):
 
             if self.proxy.stats_db:
                 self.proxy.stats_db.stop()
-            if self.warc_writer_threads[0].dedup_db:
+            if any((t.dedup_db for t in self.warc_writer_threads)):
                 self.warc_writer_threads[0].dedup_db.close()
 
             self.proxy_thread.join()


### PR DESCRIPTION
Hi Noah,

thanks for making warcproxy!
Currently, its design assumes that it's always writing to files.
I've now come across a situation where I want to serialize WARC records and send them over the network. That's pretty easy to do with all but one small change to warcproxy itself:

In order to prevent files from being written, one can pass an empty list of warc_writer_threads to the Controller. That works well, except for the zero-indexed checks for the dedup_db (see below) - if that hits an empty list, it throws a KeyError. I'd propose these two small changes which instead iterate over the list.