### PR TITLE
Add missing packages from setup.py, add tox config.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,7 @@ deps = [
     'warctools',
     'urlcanon>=0.1.dev16',
     'doublethink>=0.2.0.dev81',
-    'PySocks',
-    'warcio',
-    'requests'
+    'PySocks'
 ]
 try:
     import concurrent.futures
@@ -60,7 +58,7 @@ setuptools.setup(
         license='GPL',
         packages=['warcprox'],
         install_requires=deps,
-        tests_require=['requests>=2.0.1', 'pytest'],  # >=2.0.1 for https://github.com/kennethreitz/requests/pull/1636
+        tests_require=['requests>=2.0.1', 'pytest', 'warcio'],  # >=2.0.1 for https://github.com/kennethreitz/requests/pull/1636
         cmdclass = {'test': PyTest},
         test_suite='warcprox.tests',
         entry_points={

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ deps = [
     'warctools',
     'urlcanon>=0.1.dev16',
     'doublethink>=0.2.0.dev81',
-    'PySocks'
+    'PySocks',
 ]
 try:
     import concurrent.futures

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ deps = [
     'urlcanon>=0.1.dev16',
     'doublethink>=0.2.0.dev81',
     'PySocks',
+    'warcio',
+    'requests'
 ]
 try:
     import concurrent.futures

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,0 @@
-[tox]
-envlist=py27,py34,py35
-[testenv]
-deps=
-  pytest
-  pytest-xdist
-  requests
-  mock
-commands=py.test -n 4

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist=py27,py34,py35
+[testenv]
+deps=
+  pytest
+  pytest-xdist
+  requests
+  mock
+commands=py.test -n 4


### PR DESCRIPTION
Add missing `requests` and `warcio` packages. They are used in unit tests but
were not included in `setup.py`.

Add `tox` configuration in order to be able to run unit tests for py27,
py34 and py35 with 1 command.