### PR TITLE
Replace invalid warcfilename variable in playback

### DIFF
--- a/warcprox/playback.py
+++ b/warcprox/playback.py
@@ -131,7 +131,7 @@ class PlaybackProxyHandler(MitmProxyHandler):
                 pass
 
             if errors:
-                raise Exception('warc errors at {}:{} -- {}'.format(warcfilename, offset, errors))
+                raise Exception('warc errors at {}:{} -- {}'.format(location['f'], offset, errors))
 
             warc_type = record.get_header(warctools.WarcRecord.TYPE)
             if warc_type != warctools.WarcRecord.RESPONSE:


### PR DESCRIPTION
A warcfilename variable which does not exists is used here. Replace it
with the current variable for filename.