### PR TITLE
Add hidden --no-warc-open-suffix CLI option

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,0 +1,59 @@
+import os
+import fcntl
+from multiprocessing import Process, Queue
+from datetime import datetime
+import pytest
+from warcprox.mitmproxy import ProxyingRecorder
+from warcprox.warcproxy import RecordedUrl
+from warcprox.writer import WarcWriter
+from warcprox import Options
+
+recorder = ProxyingRecorder(None, None, 'sha1', url='http://example.com')
+
+recorded_url = RecordedUrl(url='http://example.com', content_type='text/plain',
+                           status=200, client_ip='5.5.5.5',
+                           request_data=b'abc',
+                           response_recorder=recorder,
+                           remote_ip='6.6.6.6',
+                           timestamp=datetime.utcnow())
+
+
+def lock_file(queue, filename):
+    """Try to lock file and return 1 if successful, else return 0.
+    It is necessary to run this method in a different process to test locking.
+    """
+    try:
+        fi = open(filename, 'ab')
+        fcntl.flock(fi, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fi.close()
+        queue.put('1')
+    except IOError:
+        queue.put('0')
+
+
+@pytest.mark.parametrize("no_warc_open_suffix,lock_result", [
+                         (True, '0'),
+                         (False, '1')])
+def test_warc_writer_locking(tmpdir, no_warc_open_suffix, lock_result):
+    """Test if WarcWriter is locking WARC files.
+    When we don't have the .open suffix, WarcWriter locks the file and the
+    external process trying to ``lock_file`` fails (result=0).
+    """
+    dirname = os.path.dirname(tmpdir.mkdir('test-warc-writer'))
+    wwriter = WarcWriter(Options(directory=dirname,
+                                 no_warc_open_suffix=no_warc_open_suffix))
+    wwriter.write_records(recorded_url)
+
+    if no_warc_open_suffix:
+        suffix = '.warc'
+    else:
+        suffix = '.warc.open'
+    warcs = [fn for fn in os.listdir(dirname) if fn.endswith(suffix)]
+    assert warcs
+    target_warc = os.path.join(dirname, warcs[0])
+    # launch another process and try to lock WARC file
+    queue = Queue()
+    p = Process(target=lock_file, args=(queue, target_warc))
+    p.start()
+    p.join()
+    assert queue.get() == lock_result

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -39,7 +39,7 @@ def test_warc_writer_locking(tmpdir, no_warc_open_suffix, lock_result):
     When we don't have the .open suffix, WarcWriter locks the file and the
     external process trying to ``lock_file`` fails (result=0).
     """
-    dirname = os.path.dirname(tmpdir.mkdir('test-warc-writer'))
+    dirname = os.path.dirname(str(tmpdir.mkdir('test-warc-writer')))
     wwriter = WarcWriter(Options(directory=dirname,
                                  no_warc_open_suffix=no_warc_open_suffix))
     wwriter.write_records(recorded_url)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -24,7 +24,7 @@ def lock_file(queue, filename):
     """
     try:
         fi = open(filename, 'ab')
-        fcntl.flock(fi, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.lockf(fi, fcntl.LOCK_EX | fcntl.LOCK_NB)
         fi.close()
         queue.put('1')
     except IOError:

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -78,6 +78,8 @@ def _build_arg_parser(prog=os.path.basename(sys.argv[0])):
             default='./warcs', help='where to write warcs')
     arg_parser.add_argument('-z', '--gzip', dest='gzip', action='store_true',
             help='write gzip-compressed warc records')
+    arg_parser.add_argument('--no-warc-open-suffix', dest='no_warc_open_suffix',
+            default=False, action='store_true', help=argparse.SUPPRESS)
     arg_parser.add_argument('-n', '--prefix', dest='prefix',
             default='WARCPROX', help='WARC filename prefix')
     arg_parser.add_argument(

--- a/warcprox/writer.py
+++ b/warcprox/writer.py
@@ -53,6 +53,7 @@ class WarcWriter:
         self._f = None
         self._fpath = None
         self._f_finalname = None
+        self._f_finalname_suffix = '' if options.no_warc_open_suffix else '.open'
         self._serial = 0
         self._lock = threading.RLock()
 
@@ -91,7 +92,7 @@ class WarcWriter:
                         self.prefix, self.timestamp17(), self._serial,
                         self._randomtoken, '.gz' if self.gzip else '')
                 self._fpath = os.path.sep.join([
-                    self.directory, self._f_finalname + '.open'])
+                    self.directory, self._f_finalname + self._f_finalname_suffix])
 
                 self._f = open(self._fpath, 'wb')
 

--- a/warcprox/writer.py
+++ b/warcprox/writer.py
@@ -74,7 +74,7 @@ class WarcWriter:
                 self.logger.info('closing %s', self._f_finalname)
                 if self._f_open_suffix == '':
                     try:
-                        fcntl.flock(self._f, fcntl.LOCK_UN)
+                        fcntl.lockf(self._f, fcntl.LOCK_UN)
                     except IOError as exc:
                         self.logger.error('could not unlock file %s (%s)',
                                           self._fpath, exc)
@@ -106,7 +106,7 @@ class WarcWriter:
                 # file lock.
                 if self._f_open_suffix == '':
                     try:
-                        fcntl.flock(self._f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        fcntl.lockf(self._f, fcntl.LOCK_EX | fcntl.LOCK_NB)
                     except IOError as exc:
                         self.logger.error('could not lock file %s (%s)',
                                           self._fpath, exc)


### PR DESCRIPTION
By default warcprox adds `.open` suffix in open WARC files. Using this option we disable that. The option does not appear on the program help.