### PR TITLE
Return capture timestamp

### DIFF
--- a/tests/test_warcprox.py
+++ b/tests/test_warcprox.py
@@ -557,15 +557,16 @@ def test_limits(http_daemon, warcprox_, archiving_proxies):
 
 def test_return_capture_timestamp(http_daemon, warcprox_, archiving_proxies):
     url = 'http://localhost:{}/i/j'.format(http_daemon.server_port)
-    request_meta = {"return-capture-timestamp": 1}
+    request_meta = {"accept": ["capture-metadata"]}
     headers = {"Warcprox-Meta": json.dumps(request_meta)}
     response = requests.get(url, proxies=archiving_proxies, headers=headers, stream=True)
     assert response.status_code == 200
     assert response.headers['Warcprox-Meta']
     data = json.loads(response.headers['Warcprox-Meta'])
-    assert data['capture-timestamp']
+    assert data['capture-metadata']
     try:
-        dt = datetime.datetime.strptime(data['capture-timestamp'], '%Y-%m-%d %H:%M:%S')
+        dt = datetime.datetime.strptime(data['capture-metadata']['timestamp'],
+                                        '%Y-%m-%dT%H:%M:%SZ')
         assert dt
     except ValueError:
         pytest.fail('Invalid capture-timestamp format %s', data['capture-timestamp'])

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -172,8 +172,8 @@ class ProxyingRecordingHTTPResponse(http_client.HTTPResponse):
         self.msg['Via'] = via_header_value(
                 self.msg.get('Via'), '%0.1f' % (self.version / 10.0))
         if extra_response_headers:
-            rmeta = {"capture-metadata": extra_response_headers}
-            self.msg['Warcprox-Meta'] = json.dumps(rmeta, separators=',:')
+            for header, value in extra_response_headers.items():
+                self.msg[header] = value
 
         for k,v in self.msg.items():
             if k.lower() not in (

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -373,8 +373,9 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
         bytes in transit. Returns a tuple (request, response) where request is
         the raw request bytes, and response is a ProxyingRecorder.
 
-        :param timestamp: generated on warcprox._proxy_request. It is the
-        timestamp written in the WARC record for this request.
+        :param extra_response_headers: generated on warcprox._proxy_request.
+        It may contain extra HTTP headers such as ``Warcprox-Meta`` which
+        are written in the WARC record for this request.
         '''
         # Build request
         req_str = '{} {} {}\r\n'.format(

--- a/warcprox/warcproxy.py
+++ b/warcprox/warcproxy.py
@@ -179,14 +179,13 @@ class WarcProxyHandler(warcprox.mitmproxy.MitmProxyHandler):
 
         remote_ip = self._remote_server_sock.getpeername()[0]
         timestamp = datetime.datetime.utcnow()
-
-        if warcprox_meta and 'return-capture-timestamp' in warcprox_meta:
-            return_timestamp = timestamp
-        else:
-            return_timestamp = None
+        extra_response_headers = {}
+        if warcprox_meta and 'accept' in warcprox_meta and \
+                'capture-metadata' in warcprox_meta['accept']:
+            extra_response_headers['timestamp'] = timestamp.strftime('%Y-%m-%dT%H:%M:%SZ')
 
         req, prox_rec_res = warcprox.mitmproxy.MitmProxyHandler._proxy_request(
-                self, timestamp=return_timestamp)
+                self, extra_response_headers=extra_response_headers)
 
         content_type = None
         try:

--- a/warcprox/warcproxy.py
+++ b/warcprox/warcproxy.py
@@ -182,7 +182,8 @@ class WarcProxyHandler(warcprox.mitmproxy.MitmProxyHandler):
         extra_response_headers = {}
         if warcprox_meta and 'accept' in warcprox_meta and \
                 'capture-metadata' in warcprox_meta['accept']:
-            extra_response_headers['timestamp'] = timestamp.strftime('%Y-%m-%dT%H:%M:%SZ')
+            rmeta = {'capture-metadata': {'timestamp': timestamp.strftime('%Y-%m-%dT%H:%M:%SZ')}}
+            extra_response_headers['Warcprox-Meta'] = json.dumps(rmeta, separators=',:')
 
         req, prox_rec_res = warcprox.mitmproxy.MitmProxyHandler._proxy_request(
                 self, extra_response_headers=extra_response_headers)

--- a/warcprox/warcproxy.py
+++ b/warcprox/warcproxy.py
@@ -180,8 +180,13 @@ class WarcProxyHandler(warcprox.mitmproxy.MitmProxyHandler):
         remote_ip = self._remote_server_sock.getpeername()[0]
         timestamp = datetime.datetime.utcnow()
 
+        if warcprox_meta and 'return-capture-timestamp' in warcprox_meta:
+            return_timestamp = timestamp
+        else:
+            return_timestamp = None
+
         req, prox_rec_res = warcprox.mitmproxy.MitmProxyHandler._proxy_request(
-                self)
+                self, timestamp=return_timestamp)
 
         content_type = None
         try:


### PR DESCRIPTION
When client request has HTTP header ``Warcprox-Meta": {"return-capture-timestamp": 1}``,
add to the response the WARC record timestamp in the following HTTP header:
``Warcprox-Meta: {"capture-timestamp": '%Y-%m-%d %H:%M:%S"}``.

Add unit test.