### PR TITLE
Configurable WARC filenames

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -176,13 +176,13 @@ def test_warc_writer_filename(tmpdir):
 
     dirname = os.path.dirname(str(tmpdir.mkdir('test-warc-writer')))
     wwriter = WarcWriter(Options(directory=dirname, prefix='foo',
-        warc_filename='{timestamp17}-{prefix}-{timestamp14}-{serialno}'))
+        warc_filename='{timestamp17}_{prefix}_{timestamp14}_{serialno}'))
     wwriter.write_records(recorded_url)
     warcs = [fn for fn in os.listdir(dirname)]
     assert warcs
     target_warc = os.path.join(dirname, warcs[0])
     assert target_warc
-    parts = os.path.basename(warcs[0]).split('-')
+    parts = os.path.basename(warcs[0]).split('_')
     assert len(parts[0]) == 17
     assert parts[1] == 'foo'
     assert len(parts[2]) == 14

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -176,13 +176,13 @@ def test_warc_writer_filename(tmpdir):
 
     dirname = os.path.dirname(str(tmpdir.mkdir('test-warc-writer')))
     wwriter = WarcWriter(Options(directory=dirname, prefix='foo',
-        warc_filename='{timestamp17}_{prefix}_{timestamp14}_{serialno}'))
+        warc_filename='{timestamp17}-{prefix}-{timestamp14}-{serialno}'))
     wwriter.write_records(recorded_url)
     warcs = [fn for fn in os.listdir(dirname)]
     assert warcs
     target_warc = os.path.join(dirname, warcs[0])
     assert target_warc
-    parts = warcs[0].split('_')
+    parts = os.path.basename(warcs[0]).split('-')
     assert len(parts[0]) == 17
     assert parts[1] == 'foo'
     assert len(parts[2]) == 14

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -24,6 +24,7 @@ import fcntl
 from multiprocessing import Process, Queue
 from datetime import datetime
 import pytest
+import re
 from warcprox.mitmproxy import ProxyingRecorder
 from warcprox.warcproxy import RecordedUrl
 from warcprox.writer import WarcWriter
@@ -180,10 +181,4 @@ def test_warc_writer_filename(tmpdir):
     wwriter.write_records(recorded_url)
     warcs = [fn for fn in os.listdir(dirname)]
     assert warcs
-    target_warc = os.path.join(dirname, warcs[0])
-    assert target_warc
-    parts = os.path.basename(warcs[0]).split('_')
-    assert len(parts[0]) == 17
-    assert parts[1] == 'foo'
-    assert len(parts[2]) == 14
-    assert parts[3] == '00000.warc.open'
+    assert re.match('\d{17}_foo_\d{14}_00000.warc.open', warcs[0])

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -181,4 +181,4 @@ def test_warc_writer_filename(tmpdir):
     wwriter.write_records(recorded_url)
     warcs = [fn for fn in os.listdir(dirname)]
     assert warcs
-    assert re.search('\d{17}_foo_\d{14}_00000.warc.open', warcs[0])
+    assert re.search('\d{17}_foo_\d{14}_00000.warc.open', wwriter._fpath)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -176,13 +176,13 @@ def test_warc_writer_filename(tmpdir):
 
     dirname = os.path.dirname(str(tmpdir.mkdir('test-warc-writer')))
     wwriter = WarcWriter(Options(directory=dirname, prefix='foo',
-        warc_filename='{timestamp17}-{prefix}-{timestamp14}-{serialno}'))
+        warc_filename='{timestamp17}_{prefix}_{timestamp14}_{serialno}'))
     wwriter.write_records(recorded_url)
     warcs = [fn for fn in os.listdir(dirname)]
     assert warcs
     target_warc = os.path.join(dirname, warcs[0])
     assert target_warc
-    parts = warcs[0].split('-')
+    parts = warcs[0].split('_')
     assert len(parts[0]) == 17
     assert parts[1] == 'foo'
     assert len(parts[2]) == 14

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -181,4 +181,4 @@ def test_warc_writer_filename(tmpdir):
     wwriter.write_records(recorded_url)
     warcs = [fn for fn in os.listdir(dirname)]
     assert warcs
-    assert re.match('\d{17}_foo_\d{14}_00000.warc.open', warcs[0])
+    assert re.search('\d{17}_foo_\d{14}_00000.warc.open', warcs[0])

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -77,6 +77,9 @@ def _build_arg_parser(prog):
             help='where to store and load generated certificates')
     arg_parser.add_argument('-d', '--dir', dest='directory',
             default='./warcs', help='where to write warcs')
+    arg_parser.add_argument('--warc-filename', dest='warc_filename',
+            default='{prefix}-{timestamp17}-{serialno}-{randomtoken}',
+            help='define custom WARC filename with variables {prefix}, {timestamp14}, {timestamp17}, {serialno}, {randomtoken}, {hostname}, {shorthostname}')
     arg_parser.add_argument('-z', '--gzip', dest='gzip', action='store_true',
             help='write gzip-compressed warc records')
     arg_parser.add_argument('--no-warc-open-suffix', dest='no_warc_open_suffix',

--- a/warcprox/writer.py
+++ b/warcprox/writer.py
@@ -44,7 +44,7 @@ class WarcWriter:
 
         self.gzip = options.gzip or False
         self.warc_filename = options.warc_filename or \
-            '{prefix}-{timestamp17}-{randomtoken}-{serialno}.warc'
+            '{prefix}-{timestamp17}-{randomtoken}-{serialno}'
         digest_algorithm = options.digest_algorithm or 'sha1'
         base32 = options.base32
         self.record_builder = warcprox.warc.WarcRecordBuilder(

--- a/warcprox/writer.py
+++ b/warcprox/writer.py
@@ -105,7 +105,7 @@ class WarcWriter:
         Extension ``.warc`` or ``.warc.gz`` is appended automatically.
         """
         hostname = socket.getfqdn()
-        shorthostname = hostname.split(',')[0]
+        shorthostname = hostname.split('.')[0]
         fname = self.warc_filename.format(prefix=self.prefix,
                                           timestamp14=self.timestamp14(),
                                           timestamp17=self.timestamp17(),


### PR DESCRIPTION
New ``--warc-filename`` CLI parameter with default value:
``'{prefix}-{timestamp17}-{serialno}-{randomtoken}'`` (the previous
hard-coded WARC filename format).

Use variables: ``{prefix}, {timestamp14}, {timestamp17}, {serialno},
{randomtoken}, {hostname}, {shorthostname}`` to define custom WARC filenames.