### PR TITLE
Configurable CdxServerDedup urllib3 connection pool size

### DIFF
--- a/warcprox/dedup.py
+++ b/warcprox/dedup.py
@@ -185,12 +185,12 @@ class CdxServerDedup(object):
     """Query a CDX server to perform deduplication.
     """
     logger = logging.getLogger("warcprox.dedup.CdxServerDedup")
-    http_pool = urllib3.PoolManager()
 
     def __init__(self, cdx_url="https://web.archive.org/cdx/search",
-                 options=warcprox.Options()):
+                 maxsize=200, options=warcprox.Options()):
         self.cdx_url = cdx_url
         self.options = options
+        self.http_pool = urllib3.PoolManager(maxsize=maxsize)
 
     def start(self):
         pass

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -222,7 +222,9 @@ def init_controller(args):
     elif args.rethinkdb_trough_db_url:
         dedup_db = warcprox.dedup.TroughDedupDb(options)
     elif args.cdxserver_dedup:
-        dedup_db = warcprox.dedup.CdxServerDedup(cdx_url=args.cdxserver_dedup)
+        cdxserver_maxsize = args.writer_threads or 200
+        dedup_db = warcprox.dedup.CdxServerDedup(cdx_url=args.cdxserver_dedup,
+                                                 maxsize=cdxserver_maxsize)
     elif args.dedup_db_file in (None, '', '/dev/null'):
         logging.info('deduplication disabled')
         dedup_db = None


### PR DESCRIPTION
urllib3 pool has default ``maxsize=1``
http://urllib3.readthedocs.io/en/latest/advanced-usage.html.
We need to set a higher value because we get warnings like this:
```
2018-01-15 20:04:10,044 18436 WARNING WarcWriterThread030(tid=18502)
urllib3.connectionpool._put_conn(connectionpool.py:277) Connection pool
is full, discarding connection: wwwb-dedup
```

We set value: ```cdxserver_maxsize = args.writer_threads or 200```.

Note that the ideal would be to use this
https://github.com/internetarchive/warcprox/blob/master/warcprox/main.py#L284
but it is initialized after dedup, there is a dependency and we cannot
use it.