### PR TITLE
Remove redundant file flush() in writer

### DIFF
--- a/warcprox/writer.py
+++ b/warcprox/writer.py
@@ -174,7 +174,6 @@ class WarcWriter:
                         record.get_header(warctools.WarcRecord.URL),
                         self._fpath, record.offset)
 
-            self._f.flush()
             self._last_activity = time.time()
 
         return records


### PR DESCRIPTION
We use ``record.write_to`` inside the ``WarcWriter.write_records``
method and we ``flush()`` the file after writing to make sure that data
are written to disk.

The ``record.write_to`` method already finishes with a ``flush()``!
https://github.com/internetarchive/warctools/blob/master/hanzo/warctools/warc.py#L127
Thus, it is redundant.