### PR TITLE
Improve SSL context definition

### DIFF
--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -254,9 +254,7 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
         # Wrap socket if SSL is required
         if self.is_connect:
             try:
-                context = ssl.create_default_context()
-                context.check_hostname = False
-                context.verify_mode = ssl.CERT_NONE
+                context = ssl._create_unverified_context()
                 self._remote_server_sock = context.wrap_socket(
                         self._remote_server_sock, server_hostname=self.hostname)
             except AttributeError:


### PR DESCRIPTION
Instead of creating a ``default_context`` for https and then disabling some
options related to target verification, use ``_create_unverified_context()`` at once.

https://github.com/python/cpython/blob/3.4/Lib/ssl.py#L448

It already does what is necessary regarding disabling verification and has some extra options as well.