### PR TITLE
Implement multi-threaded WARC writer architecture

### DIFF
--- a/warcprox/controller.py
+++ b/warcprox/controller.py
@@ -69,7 +69,10 @@ class Factory:
 
     @staticmethod
     def warc_writer(options):
-        return warcprox.writerthread.WarcWriterThread(options)
+        if options.writer_threads:
+            return warcprox.writerthread.WarcWriterMultiThread(options)
+        else:
+            return warcprox.writerthread.WarcWriterThread(options)
 
     @staticmethod
     def playback_proxy(ca, options):

--- a/warcprox/writerthread.py
+++ b/warcprox/writerthread.py
@@ -100,7 +100,7 @@ class WarcWriterMultiThread(WarcWriterThread):
 
     def __init__(self, options=warcprox.Options()):
         warcprox.BaseStandardPostfetchProcessor.__init__(self, options=options)
-        self.pool = futures.ThreadPoolExecutor(max_workers=10)
+        self.pool = futures.ThreadPoolExecutor(max_workers=options.writer_threads)
         self.batch = set()
         self.options = options
         self.writer_pool = warcprox.writer.WarcWriterPool(options)


### PR DESCRIPTION
Implement `MultiWarcWriter` extending `WarcWriter`.
Implement `WarcWriterMultiThread` extending `WarcWriterThread`
Load the multi-threaded classes when `--writer-threads=N` CLI option is passed, else load existing single-threaded Warc Writer.
Note that we use a `Queue` in `MultiWarcWriter` to select the next available thread for writing but we still have the thread locking. Maybe remove it if its redundant?

TODO add some unit tests.

