### PR TITLE
Add option to limit max resource size

### DIFF
--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -166,6 +166,10 @@ def _build_arg_parser(prog='warcprox'):
     arg_parser.add_argument(
             '--socket-timeout', dest='socket_timeout', type=float,
             default=None, help=argparse.SUPPRESS)
+    # Configurable max resource size in bytes, default is no limit.
+    arg_parser.add_argument(
+            '--max-resource-size', dest='max_resource_size', type=int,
+            default=None, help=argparse.SUPPRESS)
     arg_parser.add_argument(
             '--crawl-log-dir', dest='crawl_log_dir', default=None, help=(
                 'if specified, write crawl log files in the specified '

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -166,10 +166,9 @@ def _build_arg_parser(prog='warcprox'):
     arg_parser.add_argument(
             '--socket-timeout', dest='socket_timeout', type=float,
             default=None, help=argparse.SUPPRESS)
-    # Configurable max resource size in bytes, default is no limit.
     arg_parser.add_argument(
             '--max-resource-size', dest='max_resource_size', type=int,
-            default=None, help=argparse.SUPPRESS)
+            default=None, help='maximum resource size limit in bytes')
     arg_parser.add_argument(
             '--crawl-log-dir', dest='crawl_log_dir', default=None, help=(
                 'if specified, write crawl log files in the specified '

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -160,6 +160,7 @@ class ProxyingRecordingHTTPResponse(http_client.HTTPResponse):
         self.fp = self.recorder
 
         self.payload_digest = None
+        self.truncated = None
 
     def begin(self, extra_response_headers={}):
         http_client.HTTPResponse.begin(self)  # reads status line, headers
@@ -428,15 +429,15 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
             prox_rec_res.begin(extra_response_headers=extra_response_headers)
 
             buf = prox_rec_res.read(65536)
-            size = 65536
             while buf != b'':
                 buf = prox_rec_res.read(65536)
                 if self._max_resource_size:
-                    size += 65536
-                    if size > self._max_resource_size:
-                        raise Exception(
-                            'Max resource size %d bytes exceeded for URL %s' %
-                            (self._max_resource_size, self.url))
+                    if prox_rec_res.recorder.len > self._max_resource_size:
+                        prox_rec_res.truncated = b'length'
+                        self.logger.error(
+                            'Max resource size %d bytes exceeded for URL %s',
+                            self._max_resource_size, self.url)
+                        break
 
             self.log_request(prox_rec_res.status, prox_rec_res.recorder.len)
         finally:

--- a/warcprox/warc.py
+++ b/warcprox/warc.py
@@ -67,7 +67,8 @@ class WarcRecordBuilder:
                     content_type=hanzo.httptools.ResponseMessage.CONTENT_TYPE,
                     remote_ip=recorded_url.remote_ip,
                     payload_digest=warcprox.digest_str(
-                        recorded_url.payload_digest, self.base32))
+                        recorded_url.payload_digest, self.base32),
+                    truncated=recorded_url.truncated)
 
     def build_warc_records(self, recorded_url):
         """Returns a tuple of hanzo.warctools.warc.WarcRecord (principal_record, ...)"""
@@ -91,7 +92,7 @@ class WarcRecordBuilder:
     def build_warc_record(self, url, warc_date=None, recorder=None, data=None,
         concurrent_to=None, warc_type=None, content_type=None, remote_ip=None,
         profile=None, refers_to=None, refers_to_target_uri=None,
-        refers_to_date=None, payload_digest=None):
+        refers_to_date=None, payload_digest=None, truncated=None):
 
         if warc_date is None:
             warc_date = warctools.warc.warc_datetime_str(datetime.datetime.utcnow())
@@ -120,6 +121,9 @@ class WarcRecordBuilder:
             headers.append((warctools.WarcRecord.CONTENT_TYPE, content_type))
         if payload_digest is not None:
             headers.append((warctools.WarcRecord.PAYLOAD_DIGEST, payload_digest))
+        # truncated value may be 'length' or 'time'
+        if truncated is not None:
+            headers.append((b'WARC-Truncated', truncated))
 
         if recorder is not None:
             headers.append((warctools.WarcRecord.CONTENT_LENGTH, str(len(recorder)).encode('latin1')))

--- a/warcprox/warcproxy.py
+++ b/warcprox/warcproxy.py
@@ -399,6 +399,8 @@ class SingleThreadedWarcProxy(http_server.HTTPServer, object):
 
         if options.socket_timeout:
             WarcProxyHandler._socket_timeout = options.socket_timeout
+        if options.max_resource_size:
+            WarcProxyHandler._max_resource_size = options.max_resource_size
 
         http_server.HTTPServer.__init__(
                 self, server_address, WarcProxyHandler, bind_and_activate=True)

--- a/warcprox/warcproxy.py
+++ b/warcprox/warcproxy.py
@@ -221,7 +221,8 @@ class WarcProxyHandler(warcprox.mitmproxy.MitmProxyHandler):
                 timestamp=timestamp, host=self.hostname,
                 duration=datetime.datetime.utcnow()-timestamp,
                 referer=self.headers.get('referer'),
-                payload_digest=prox_rec_res.payload_digest)
+                payload_digest=prox_rec_res.payload_digest,
+                truncated=prox_rec_res.truncated)
         self.server.recorded_url_q.put(recorded_url)
 
         return recorded_url
@@ -330,7 +331,7 @@ class RecordedUrl:
             warcprox_meta=None, content_type=None, custom_type=None,
             status=None, size=None, client_ip=None, method=None,
             timestamp=None, host=None, duration=None, referer=None,
-            payload_digest=None, warc_records=None):
+            payload_digest=None, truncated=None, warc_records=None):
         # XXX should test what happens with non-ascii url (when does
         # url-encoding happen?)
         if type(url) is not bytes:
@@ -369,6 +370,7 @@ class RecordedUrl:
         self.duration = duration
         self.referer = referer
         self.payload_digest = payload_digest
+        self.truncated = truncated
         self.warc_records = warc_records
 
 # inherit from object so that multiple inheritance from this class works


### PR DESCRIPTION
Add hidden option ``--max-resource-size`` which indicates the max file size of
a target resource in bytes. If the size is over the limit, an exception is
raised.