### PR TITLE
Use updated list of SSL ciphers

### DIFF
--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -64,6 +64,7 @@ import urlcanon
 import time
 import collections
 import cProfile
+from urllib3.util.ssl_ import DEFAULT_CIPHERS
 
 class ProxyingRecorder(object):
     """
@@ -257,8 +258,10 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
                 context = ssl.create_default_context()
                 context.check_hostname = False
                 context.verify_mode = ssl.CERT_NONE
+                context.ciphers = DEFAULT_CIPHERS
                 self._remote_server_sock = context.wrap_socket(
-                        self._remote_server_sock, server_hostname=self.hostname)
+                        self._remote_server_sock, server_hostname=self.hostname,
+                        )
             except AttributeError:
                 try:
                     self._remote_server_sock = ssl.wrap_socket(

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -260,8 +260,7 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
                 context.verify_mode = ssl.CERT_NONE
                 context.ciphers = DEFAULT_CIPHERS
                 self._remote_server_sock = context.wrap_socket(
-                        self._remote_server_sock, server_hostname=self.hostname,
-                        )
+                        self._remote_server_sock, server_hostname=self.hostname)
             except AttributeError:
                 try:
                     self._remote_server_sock = ssl.wrap_socket(


### PR DESCRIPTION
We use the default list of SSL ciphers of python `ssl` module when we connect
to remote hosts. That list is probably outdated.
https://github.com/python/cpython/blob/3.6/Lib/ssl.py#L192

We noticed problems when connection to various targets. E.g.

```
2018-01-31 21:29:23,870 3067 WARNING
MitmProxyHandler(tid=8052,started=2018-01-31T21:29:22.501118,client=127.0.0.1:56340)
warcprox.warcprox.WarcProxyHandler.log_error(mitmproxy.py:447) code 500,
message EOF occurred in violation of protocol (_ssl.c:645)

2018-01-31 21:29:23,987 3067 ERROR
MitmProxyHandler(tid=7327,started=2018-01-31T21:29:22.741262,client=127.0.0.1:56448)
warcprox.warcprox.WarcProxyHandler.do_CONNECT(mitmproxy.py:311) problem
handling 'CONNECT beacon.krxd.net:443 HTTP/1.1': SSLEOFError(8, 'EOF
occurred in violation of protocol (_ssl.c:645)')

2018-01-31 21:29:23,870 3067 ERROR
MitmProxyHandler(tid=8052,started=2018-01-31T21:29:22.501118,client=127.0.0.1:56340)
warcprox.warcprox.WarcProxyH
andler.do_CONNECT(mitmproxy.py:311) problem handling 'CONNECT
px.surveywall-api.survata.com:443 HTTP/1.1': SSLEOFError(8, 'EOF
occurred in violation
 of protocol (_ssl.c:645)')
```

Research indicated that the cipher selection is not proper.

I use `urllib3` cipher selection for better compatibility.

https://github.com/shazow/urllib3/blob/master/urllib3/util/ssl_.py#L71

The `urllib3` list is bigger and includes TLS13 which from my experience
is the latest state of the art.

`ssl` module ciphers:
```
'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+HIGH:DH+HIGH:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+HIGH:RSA+3DES:ECDH+RC4:DH+RC4:RSA+RC4:!aNULL:!eNULL:!MD5'
```
`urllib3` module ciphers:
```
'TLS13-AES-256-GCM-SHA384:TLS13-CHACHA20-POLY1305-SHA256:TLS13-AES-128-GCM-SHA256:ECDH+AESGCM:ECDH+CHACHA20:DH+AESGCM:DH+CHACHA20:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!eNULL:!MD5'
```