### PR TITLE
Support client connections using HTTP/1.1

### DIFF
--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -206,6 +206,7 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
     man-in-the-middle in order to peek at the content of https transactions,
     and records the bytes in transit as it proxies them.
     '''
+    protocol_version = 'HTTP/1.1'
     logger = logging.getLogger("warcprox.mitmproxy.MitmProxyHandler")
     _socket_timeout = 60
     _max_resource_size = None


### PR DESCRIPTION
We extend `http.server.BaseHTTPRequestHandler` which uses HTTP/1.0 by
default.
https://github.com/python/cpython/blob/3.4/Lib/http/server.py#L580

We set this to `protocol_version = "HTTP/1.1"` to enable automatic keepalive
as it is also hinted in their comment:
_# Set this to HTTP/1.1 to enable automatic keepalive_