### PR TITLE
Generate wildcard certs to reduce the number of certs generated

### DIFF
--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -278,7 +278,7 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
         return self._remote_server_sock
 
     def _transition_to_ssl(self):
-        certfile = self.server.ca.cert_for_host(self.hostname)
+        certfile = self.server.ca.get_wildcard_cert(self.hostname)
         self.request = self.connection = ssl.wrap_socket(
                 self.connection, server_side=True, certfile=certfile)
         # logging.info('self.hostname=%s certfile=%s', self.hostname, certfile)


### PR DESCRIPTION
`certauth` has a method to create a cert for `*.example.com`. This
reduces greatly the number of generated certificates (~50% in my
tests).
For example, previous code would create:
```
images-eu.ssl-images-amazon.com.pem
images-fe.ssl-images-amazon.com.pem
images-na.ssl-images-amazon.com.pem
```
Wildcard code would create:
```
ssl-images-amazon.com.pem
```