### PR TITLE
Remote server connection pooling

### DIFF
--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -260,6 +260,8 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
                 self._remote_server_conn.sock.set_proxy(
                         socks.SOCKS5, addr=self.onion_tor_socks_proxy_host,
                         port=self.onion_tor_socks_proxy_port, rdns=True)
+                self._remote_server_conn.timeout = self._socket_timeout
+                self._remote_server_conn.sock.connect((self.hostname, int(self.port)))
             else:
                 self._remote_server_conn.timeout = self._socket_timeout
                 self._remote_server_conn.connect()

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -176,7 +176,7 @@ class ProxyingRecordingHTTPResponse(http_client.HTTPResponse):
 
         for k,v in self.msg.items():
             if k.lower() not in (
-                    'connection', 'proxy-connection', 'keep-alive',
+                    'connection', 'proxy-connection',
                     'proxy-authenticate', 'proxy-authorization', 'upgrade',
                     'strict-transport-security'):
                 status_and_headers += '{}: {}\r\n'.format(k, v)
@@ -247,7 +247,7 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
         '''
         self._conn_pool = self.server.remote_connection_pool.connection_from_host(
             host=self.hostname, port=int(self.port), scheme='http',
-            pool_kwargs={'maxsize': 100})
+            pool_kwargs={'maxsize': 30})
 
         self._remote_server_conn = self._conn_pool._get_conn()
         if is_connection_dropped(self._remote_server_conn):
@@ -257,7 +257,7 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
                         self.onion_tor_socks_proxy_host,
                         self.onion_tor_socks_proxy_port or 1080, self.hostname)
                 self._remote_server_conn.sock = socks.socksocket()
-                self._remote_server_sock.set_proxy(
+                self._remote_server_conn.sock.set_proxy(
                         socks.SOCKS5, addr=self.onion_tor_socks_proxy_host,
                         port=self.onion_tor_socks_proxy_port, rdns=True)
             else:

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -250,7 +250,7 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
             pool_kwargs={'maxsize': 100})
 
         self._remote_server_conn = self._conn_pool._get_conn()
-        if self._remote_server_conn.sock is None:
+        if is_connection_dropped(self._remote_server_conn):
             if self.onion_tor_socks_proxy_host and self.hostname.endswith('.onion'):
                 self.logger.info(
                         "using tor socks proxy at %s:%s to connect to %s",

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -64,6 +64,7 @@ import urlcanon
 import time
 import collections
 import cProfile
+from urllib3.util import is_connection_dropped
 
 class ProxyingRecorder(object):
     """
@@ -456,7 +457,7 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
             # put it back in the pool to reuse it later.
             if prox_rec_res:
                 prox_rec_res.close()
-            if connection_is_fine:
+            if connection_is_fine and not is_connection_dropped(self._remote_server_conn):
                 self._conn_pool._put_conn(self._remote_server_conn)
             else:
                 self._remote_server_conn.sock.close()

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -282,7 +282,6 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
                                 "upgrading to python >= 2.7.9 or python 3.4",
                                 self.hostname)
                     raise
-
         return self._remote_server_conn.sock
 
     def _transition_to_ssl(self):
@@ -458,7 +457,7 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
             if prox_rec_res:
                 prox_rec_res.close()
             if connection_is_fine:
-                self._conn_pool._put_conn(self._remote_conn)
+                self._conn_pool._put_conn(self._remote_server_conn)
             else:
                 self._remote_server_conn.sock.close()
 

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -65,8 +65,6 @@ import time
 import collections
 import cProfile
 
-
-
 class ProxyingRecorder(object):
     """
     Wraps a socket._fileobject, recording the bytes as they are read,

--- a/warcprox/warcproxy.py
+++ b/warcprox/warcproxy.py
@@ -388,7 +388,8 @@ class SingleThreadedWarcProxy(http_server.HTTPServer, object):
         self.status_callback = status_callback
         self.stats_db = stats_db
         self.options = options
-        self.remote_connection_pool = PoolManager(num_pools=2000)
+        self.remote_connection_pool = PoolManager(
+            num_pools=max(options.max_threads, 500) if options.max_threads else 500)
         server_address = (
                 options.address or 'localhost',
                 options.port if options.port is not None else 8000)

--- a/warcprox/warcproxy.py
+++ b/warcprox/warcproxy.py
@@ -389,7 +389,7 @@ class SingleThreadedWarcProxy(http_server.HTTPServer, object):
         self.stats_db = stats_db
         self.options = options
         self.remote_connection_pool = PoolManager(
-            num_pools=max(options.max_threads, 500) if options.max_threads else 500)
+            num_pools=max(round(options.max_threads / 6), 200) if options.max_threads else 200)
         server_address = (
                 options.address or 'localhost',
                 options.port if options.port is not None else 8000)


### PR DESCRIPTION
Use urllib3 connection pooling to improve remote server connection
speed. Our aim is to reuse socket connections to the same target hosts when
possible.

Initialize a `urllib3.PoolManager` in `SingleThreadedWarcProxy` and use
it in `MitmProxyHandler` to connect to remote servers.
Socket read / write and ssl / socks code is exactly the same, only the
connection management changes.

Use arbitratry settings: `pool_size=2000` and `maxsize=100` (number of
connections per host) for now. Maybe we can come up with better values in the
future.