### PR TITLE
Configurable SpooledTemporaryFile max memory size

### DIFF
--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -166,6 +166,10 @@ def _build_arg_parser(prog='warcprox'):
     arg_parser.add_argument(
             '--socket-timeout', dest='socket_timeout', type=float,
             default=None, help=argparse.SUPPRESS)
+    # Increasing this value increases memory usage but reduces /tmp disk I/O.
+    arg_parser.add_argument(
+            '--tmp-file-max-memory-size', dest='tmp_file_max_memory_size',
+            type=int, default=512*1024, help=argparse.SUPPRESS)
     arg_parser.add_argument(
             '--max-resource-size', dest='max_resource_size', type=int,
             default=None, help='maximum resource size limit in bytes')

--- a/warcprox/warcproxy.py
+++ b/warcprox/warcproxy.py
@@ -405,6 +405,8 @@ class SingleThreadedWarcProxy(http_server.HTTPServer, object):
             WarcProxyHandler._socket_timeout = options.socket_timeout
         if options.max_resource_size:
             WarcProxyHandler._max_resource_size = options.max_resource_size
+        if options.tmp_file_max_memory_size:
+            WarcProxyHandler._tmp_file_max_memory_size = options.tmp_file_max_memory_size
 
         http_server.HTTPServer.__init__(
                 self, server_address, WarcProxyHandler, bind_and_activate=True)


### PR DESCRIPTION
We use `tempfile.SpooledTemporaryFile(max_size=512*1024)` to keep
recorded data before writing them to WARC.
Data are kept in memory when they are smaller than `max_size`, else they
are written to disk.

We add the hidden option `--tmp-file-max-memory-size` to make this configurable.
A higher value means less /tmp disk I/O and higher overall performance but
also increased memory usage.