### PR TITLE
CDX Dedup improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except:
 
 setuptools.setup(
         name='warcprox',
-        version='2.4b2.dev157',
+        version='2.4b2.dev158',
         description='WARC writing MITM HTTP/S proxy',
         url='https://github.com/internetarchive/warcprox',
         author='Noah Levitt',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except:
 
 setuptools.setup(
         name='warcprox',
-        version='2.4b2.dev158',
+        version='2.4b2.dev159',
         description='WARC writing MITM HTTP/S proxy',
         url='https://github.com/internetarchive/warcprox',
         author='Noah Levitt',

--- a/warcprox/__init__.py
+++ b/warcprox/__init__.py
@@ -130,7 +130,7 @@ class BasePostfetchProcessor(threading.Thread):
         raise Exception('not implemented')
 
     def _run(self):
-        logging.info('%s starting up', self)
+        self.logger.info('%s starting up', self)
         self._startup()
         while not self.stop.is_set():
             try:
@@ -140,7 +140,7 @@ class BasePostfetchProcessor(threading.Thread):
                     except queue.Empty:
                         if self.stop.is_set():
                             break
-                logging.info('%s shutting down', self)
+                self.logger.info('%s shutting down', self)
                 self._shutdown()
             except Exception as e:
                 if isinstance(e, OSError) and e.errno == 28:

--- a/warcprox/dedup.py
+++ b/warcprox/dedup.py
@@ -205,17 +205,18 @@ class CdxServerDedup(DedupDb):
     cookies = None
 
     def __init__(self, cdx_url="https://web.archive.org/cdx/search",
-                 maxsize=200, options=warcprox.Options()):
+                 maxsize=400, options=warcprox.Options()):
         """Initialize cdx server connection pool and related parameters.
         Use low timeout value and no retries to avoid blocking warcprox
         operation by a slow CDX server.
         """
         self.cdx_url = cdx_url
         self.options = options
-        self.http_pool = urllib3.PoolManager(maxsize=maxsize, retries=0,
-                                             timeout=2.0)
+        headers = {'user-agent': 'warcprox', 'accept': 'gzip/deflate'}
         if options.cdxserver_dedup_cookies:
-            self.cookies = options.cdxserver_dedup_cookies
+            headers['Cookie'] = options.cdxserver_dedup_cookies
+        self.http_pool = urllib3.PoolManager(maxsize=maxsize, retries=0,
+                                             timeout=2.0, headers=headers)
 
     def loader(self, *args, **kwargs):
         return CdxServerDedupLoader(self, self.options)
@@ -245,10 +246,9 @@ class CdxServerDedup(DedupDb):
         """
         u = url.decode("utf-8") if isinstance(url, bytes) else url
         try:
-            headers = {'Cookie': self.cookies} if self.cookies else {}
             result = self.http_pool.request('GET', self.cdx_url, fields=dict(
                 url=u, fl="timestamp,digest", filter="!mimetype:warc/revisit",
-                limit=-1), headers=headers)
+                limit=-1))
             assert result.status == 200
             if isinstance(digest_key, bytes):
                 dkey = digest_key
@@ -276,7 +276,7 @@ class CdxServerDedup(DedupDb):
 class CdxServerDedupLoader(warcprox.BaseBatchPostfetchProcessor):
     def __init__(self, cdx_dedup, options=warcprox.Options()):
         warcprox.BaseBatchPostfetchProcessor.__init__(self, options)
-        self.pool = futures.ThreadPoolExecutor(max_workers=200)
+        self.pool = futures.ThreadPoolExecutor(max_workers=400)
         self.batch = set()
         self.cdx_dedup = cdx_dedup
 

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -462,6 +462,7 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
                 self._conn_pool._put_conn(self._remote_server_conn)
         except:
             self._remote_server_conn.sock.close()
+            raise
         finally:
             if prox_rec_res:
                 prox_rec_res.close()

--- a/warcprox/writerthread.py
+++ b/warcprox/writerthread.py
@@ -44,6 +44,10 @@ class WarcWriterProcessor(warcprox.BaseStandardPostfetchProcessor):
         self.pool = futures.ThreadPoolExecutor(max_workers=options.writer_threads or 1)
         self.batch = set()
 
+    def _startup(self):
+        self.logger.info('%s threads', self.pool._max_workers)
+        warcprox.BaseStandardPostfetchProcessor._startup(self)
+
     def _get_process_put(self):
         try:
             recorded_url = self.inq.get(block=True, timeout=0.5)


### PR DESCRIPTION
Increase CDX dedup max workers from 200 to 400 in order to handle more
load.

Set `user-agent: warcprox` for HTTP requests we send to CDX server. Its
useful to identify and monitor `warcprox` requests.

Pass HTTP headers to connection pool on init and not on each request.