### PR TITLE
Increase proxy_client socket send buffer and use TCP_NODELAY

### DIFF
--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -83,6 +83,8 @@ class ProxyingRecorder(object):
         self.block_digest = hashlib.new(digest_algorithm)
         self.payload_offset = None
         self.proxy_client = proxy_client
+        self.proxy_client.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 65536)
+        self.proxy_client.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         self._proxy_client_conn_open = bool(self.proxy_client)
         self.len = 0
         self.url = url


### PR DESCRIPTION
Python `socket.send` buffer has default value 8192.
We receive data in big chunks with `prox_rec_res.read(65536)` but we send them
in much smaller chunks (8192) to the client. We should use the same
size to improve performance.

We also didn't use `TCP_NODELAY` for the proxy client and enabling it
helps performance.