### PR TITLE
ProxyingRecorder block_digest optimisation

### DIFF
--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -91,7 +91,6 @@ class ProxyingRecorder(object):
         self.payload_offset = self.len
 
     def _update(self, hunk):
-        self.block_digest.update(hunk)
         self.tempfile.write(hunk)
 
         if self.payload_offset is not None and self._proxy_client_conn_open:
@@ -129,6 +128,11 @@ class ProxyingRecorder(object):
         return self.fp.flush()
 
     def close(self):
+        """Update block_digest when closing ProxyingRecorder and the tempfile
+        is complete. Read 1MB chunks for faster performance.
+        """
+        for hunk in iter(lambda: self.tempfile.read(1048576), b''):
+            self.block_digest.update(hunk)
         return self.fp.close()
 
     def __len__(self):


### PR DESCRIPTION
Instead of doing `self.block_digest.update(hunk)` every time we read
some data from the remote server, we do it in the end of the
transmission, when `ProxyingRecorder.close()` is invoked.

I noticed that we update `block_digest` on every remote socket read but
it is not used until much later, when we write to the WARC file.
https://github.com/internetarchive/warcprox/blob/master/warcprox/warc.py#L131

So, we shouldn't block reading with this but we can do in the end of the
transaction and much faster using 1MB chunks instead of 64KB chunks.
The result is exactly the same.

Initial profiling info:
```
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
151718  189.786    0.001  189.786    0.001 {method 'update' of '_hashlib.HASH' objects}
```
After the improvement:
```
12111   74.139    0.006   74.139    0.006 {method 'update' of '_hashlib.HASH' objects}
```