### PR TITLE
Max request duration limit

### DIFF
--- a/tests/test_warcprox.py
+++ b/tests/test_warcprox.py
@@ -406,7 +406,7 @@ def warcprox_(request, http_daemon, https_daemon):
             '--crawl-log-dir=crawl-logs',
             '--socket-timeout=4',
             '--max-resource-size=200000',
-            '--max-request-duration=15']
+            '--max-request-duration=7']
     if request.config.getoption('--rethinkdb-dedup-url'):
         argv.append('--rethinkdb-dedup-url=%s' % request.config.getoption('--rethinkdb-dedup-url'))
         # test these here only
@@ -1312,9 +1312,8 @@ def test_limit_large_resource(archiving_proxies, http_daemon, warcprox_):
 
 def test_limit_request_duration(archiving_proxies, http_daemon, warcprox_):
     """We try to load a gradual response which runs for 20 sec and downloads
-    20k. We use --max-request-duration=15 in `warcprox_` so it will be
+    20k. We use --max-request-duration=7 in `warcprox_` so it will be
     truncated and download less.
-    WARNING this crashes with a socket exception
     """
     urls_before = warcprox_.proxy.running_stats.urls
 

--- a/tests/test_warcprox.py
+++ b/tests/test_warcprox.py
@@ -277,9 +277,20 @@ class _TestHttpRequestHandler(http_server.BaseHTTPRequestHandler):
 
     def do_GET(self):
         logging.info('GET {}'.format(self.path))
-        headers, payload = self.build_response()
-        self.connection.sendall(headers)
-        self.connection.sendall(payload)
+        if self.path == '/slow-gradual-response':
+            if self.path == '/slow-gradual-response':
+                headers = (b'HTTP/1.1 200 OK\r\n'
+                        +  b'Content-Type: text/plain\r\n'
+                        +  b'Content-Length: 20000\r\n'
+                        +  b'\r\n')
+                self.connection.sendall(headers)
+                for i in range(20):
+                    time.sleep(1)
+                    self.connection.send(b'x' * 1000)
+        else:
+            headers, payload = self.build_response()
+            self.connection.sendall(headers)
+            self.connection.sendall(payload)
         if self.path in ('/missing-content-length', '/empty-response'):
             # server must close the connection, else client has no idea if
             # there is more data coming
@@ -394,7 +405,8 @@ def warcprox_(request, http_daemon, https_daemon):
             '--onion-tor-socks-proxy=localhost:9050',
             '--crawl-log-dir=crawl-logs',
             '--socket-timeout=4',
-            '--max-resource-size=200000']
+            '--max-resource-size=200000',
+            '--max-request-duration=15']
     if request.config.getoption('--rethinkdb-dedup-url'):
         argv.append('--rethinkdb-dedup-url=%s' % request.config.getoption('--rethinkdb-dedup-url'))
         # test these here only
@@ -1297,6 +1309,33 @@ def test_limit_large_resource(archiving_proxies, http_daemon, warcprox_):
     # wait for processing of this url to finish so that it doesn't interfere
     # with subsequent tests
     wait(lambda: warcprox_.proxy.running_stats.urls - urls_before == 2)
+
+def test_limit_request_duration(archiving_proxies, http_daemon, warcprox_):
+    """We try to load a 300k response but we use --max-resource-size=200000 in
+    `warcprox_` so it will be truncated. We expect it to limit the result as
+    soon as it passes the 200000 limit. As warcprox read() chunk size is 65536,
+    the expected result size is 65536*4=262144.
+    """
+    urls_before = warcprox_.proxy.running_stats.urls
+
+    # this should be truncated
+    url = 'http://localhost:%s/slow-gradual-response' % http_daemon.server_port
+    response = requests.get(
+        url, proxies=archiving_proxies, verify=False, timeout=30)
+    assert len(response.content) < 20000
+
+    # test that the connection is cleaned up properly after truncating a
+    # response (no hang or timeout)
+    url = 'http://localhost:%s/' % http_daemon.server_port
+    response = requests.get(
+        url, proxies=archiving_proxies, verify=False, timeout=10)
+    assert response.status_code == 404
+    assert response.content == b'404 Not Found\n'
+
+    # wait for processing of this url to finish so that it doesn't interfere
+    # with subsequent tests
+    wait(lambda: warcprox_.proxy.running_stats.urls - urls_before == 2)
+
 
 def test_method_filter(
         warcprox_, https_daemon, http_daemon, archiving_proxies,

--- a/tests/test_warcprox.py
+++ b/tests/test_warcprox.py
@@ -1311,10 +1311,10 @@ def test_limit_large_resource(archiving_proxies, http_daemon, warcprox_):
     wait(lambda: warcprox_.proxy.running_stats.urls - urls_before == 2)
 
 def test_limit_request_duration(archiving_proxies, http_daemon, warcprox_):
-    """We try to load a 300k response but we use --max-resource-size=200000 in
-    `warcprox_` so it will be truncated. We expect it to limit the result as
-    soon as it passes the 200000 limit. As warcprox read() chunk size is 65536,
-    the expected result size is 65536*4=262144.
+    """We try to load a gradual response which runs for 20 sec and downloads
+    20k. We use --max-request-duration=15 in `warcprox_` so it will be
+    truncated and download less.
+    WARNING this crashes with a socket exception
     """
     urls_before = warcprox_.proxy.running_stats.urls
 

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -174,6 +174,9 @@ def _build_arg_parser(prog='warcprox'):
             '--max-resource-size', dest='max_resource_size', type=int,
             default=None, help='maximum resource size limit in bytes')
     arg_parser.add_argument(
+            '--max-request-duration', dest='max_request_duration', type=int,
+            default=None, help='maximum time a request can be executed in seconds')
+    arg_parser.add_argument(
             '--crawl-log-dir', dest='crawl_log_dir', default=None, help=(
                 'if specified, write crawl log files in the specified '
                 'directory; one crawl log is written per warc filename '

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -135,10 +135,6 @@ class ProxyingRecorder(object):
     def __len__(self):
         return self.len
 
-    @property
-    def duration(self):
-        return round(time.time() - self.start_time, 3)
-
     def payload_size(self):
         if self.payload_offset is not None:
             return self.len - self.payload_offset
@@ -425,6 +421,7 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
         It may contain extra HTTP headers such as ``Warcprox-Meta`` which
         are written in the WARC record for this request.
         '''
+        start = time.time()
         # Build request
         req_str = '{} {} {}\r\n'.format(
                 self.command, self.path, self.request_version)
@@ -482,7 +479,7 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
                             self._max_resource_size, self.url)
                     break
                 if (self._max_request_duration and
-                        prox_rec_res.recorder.duration > self._max_request_duration):
+                        time.time() - start > self._max_request_duration):
                     prox_rec_res.truncated = b'time'
                     self._remote_server_conn.sock.shutdown(socket.SHUT_RDWR)
                     self._remote_server_conn.sock.close()

--- a/warcprox/warcproxy.py
+++ b/warcprox/warcproxy.py
@@ -407,6 +407,8 @@ class SingleThreadedWarcProxy(http_server.HTTPServer, object):
             WarcProxyHandler._socket_timeout = options.socket_timeout
         if options.max_resource_size:
             WarcProxyHandler._max_resource_size = options.max_resource_size
+        if options.max_request_duration:
+            WarcProxyHandler._max_request_duration = options.max_request_duration
         if options.tmp_file_max_memory_size:
             WarcProxyHandler._tmp_file_max_memory_size = options.tmp_file_max_memory_size
 


### PR DESCRIPTION
Currently, there is no max running time for a request, we need to make this configurable.

Add CLI option `--max-request-duration` with default value `None`.

Add `ProxyingRecorder.duration` property which returns the request
duration is seconds.

If request duration exceeds the max request duration time, terminate the
request and write a record with a `Write WARC-Truncated: time` header.

Follow exactly the same process as with the resource size max limit.

TODO, if this looks fine, I'll add a unit test.