### PR TITLE
Max request duration option

### DIFF
--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -184,6 +184,9 @@ def _build_arg_parser(prog='warcprox'):
             '--max-resource-size', dest='max_resource_size', type=int,
             default=None, help='maximum resource size limit in bytes')
     arg_parser.add_argument(
+            '--max-request-duration', dest='max_request_duration', type=int,
+            default=None, help='maximum time a request can be executed in seconds')
+    arg_parser.add_argument(
             '--crawl-log-dir', dest='crawl_log_dir', default=None, help=(
                 'if specified, write crawl log files in the specified '
                 'directory; one crawl log is written per warc filename '

--- a/warcprox/warcproxy.py
+++ b/warcprox/warcproxy.py
@@ -423,6 +423,8 @@ class SingleThreadedWarcProxy(http_server.HTTPServer, object):
             WarcProxyHandler._socket_timeout = options.socket_timeout
         if options.max_resource_size:
             WarcProxyHandler._max_resource_size = options.max_resource_size
+        if options.max_request_duration:
+            WarcProxyHandler._max_request_duration = options.max_request_duration
         if options.tmp_file_max_memory_size:
             WarcProxyHandler._tmp_file_max_memory_size = options.tmp_file_max_memory_size
 


### PR DESCRIPTION
Currently, there is no max running time for a request, we need to make
this configurable.

Add CLI option `--max-request-duration` with default value None.

If request duration exceeds the max request duration time, terminate the
request and write a record with a Write `WARC-Truncated: time` header.

Regarding unit tests, use `--max-request-duration=7` and implement a
`/slow-gradual-response` which would normally take 20 sec and is
truncated.
Also, implement `/fast-gradual-response` which needs 4 sec and is not
truncated.
Both tests send data at 70k chunks with 1 sec interval.

A "trick" required to make the unit tests runs properly is to send data
larger than 65536 bytes which is used in `proxy_rec_res.read(65536)` to
read data from the remote server. If we test with smaller sizes, socket
buffering interferes and breaks the test. This was identified here: https://github.com/internetarchive/warcprox/pull/89

We also set `--max-resource-size=2000000` and modify
`test_max_resource_size` accordingly because the previous small resource
size (200000) interfered with the new tests.