### PR TITLE
New --black-out-period option to skip writing redundant revisits to WARC

### DIFF
--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -158,6 +158,9 @@ def _build_arg_parser(prog='warcprox'):
     # Warcprox-Meta HTTP header. By default, we dedup all requests.
     arg_parser.add_argument('--dedup-only-with-bucket', dest='dedup_only_with_bucket',
                             action='store_true', default=False, help=argparse.SUPPRESS)
+    arg_parser.add_argument('--black-out-period', dest='black_out_period',
+                            type=int, default=0,
+                            help='skip writing a revisit record if its too close to the original capture')
     arg_parser.add_argument('--queue-size', dest='queue_size', type=int,
             default=500, help=argparse.SUPPRESS)
     arg_parser.add_argument('--max-threads', dest='max_threads', type=int,


### PR DESCRIPTION
Add option `--black-out-period` (default=0).

When set and if the record is a duplicate, check the datetime of `dedup_info`
 and if its very recent (`(datetime.utcnow() - dedup_datetime) <= black_out_period`)
avoid writing the revisit record to WARC.

Add some unit tests.