### PR TITLE
New --blackout-period option to skip writing redundant revisits to WARC

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -22,7 +22,7 @@ USA.
 import os
 import fcntl
 from multiprocessing import Process, Queue
-from datetime import datetime
+from datetime import datetime, timedelta
 import pytest
 import re
 from warcprox.mitmproxy import ProxyingRecorder
@@ -129,7 +129,7 @@ def test_special_dont_write_prefix():
             wwt.join()
 
         wwt = warcprox.writerthread.WarcWriterProcessor(
-                Options(writer_threads=1))
+                Options(writer_threads=1, blackout_period=60, prefix='foo'))
         wwt.inq = warcprox.TimestampedQueue(maxsize=1)
         wwt.outq = warcprox.TimestampedQueue(maxsize=1)
         try:
@@ -158,6 +158,42 @@ def test_special_dont_write_prefix():
             recorded_url = wwt.outq.get(timeout=10)
             assert not recorded_url.warc_records
             assert wwt.outq.empty()
+
+            # test blackout_period option. Write first revisit record because
+            # its outside the blackout_period (60). Do not write the second
+            # because its inside the blackout_period.
+            recorder = ProxyingRecorder(io.BytesIO(b'test1'), None)
+            recorder.read()
+            old = datetime.utcnow() - timedelta(0, 3600)
+            ru = RecordedUrl(
+                url='http://example.com/yes',
+                # content_type=hanzo.httptools.ResponseMessage.CONTENT_TYPE,
+                content_type='text/plain',
+                status=200, client_ip='127.0.0.2', request_data=b'abc',
+                response_recorder=recorder, remote_ip='127.0.0.3',
+                timestamp=datetime.utcnow(),
+                payload_digest=recorder.block_digest)
+            ru.dedup_info = dict(id=b'1', url=b'http://example.com/dup',
+                                 date=old.strftime('%Y-%m-%dT%H:%M:%SZ').encode('utf-8'))
+            wwt.inq.put(ru)
+            recorded_url = wwt.outq.get(timeout=10)
+            recorder = ProxyingRecorder(io.BytesIO(b'test2'), None)
+            recorder.read()
+            recent = datetime.utcnow() - timedelta(0, 5)
+            ru = RecordedUrl(
+                url='http://example.com/yes', content_type='text/plain',
+                status=200, client_ip='127.0.0.2', request_data=b'abc',
+                response_recorder=recorder, remote_ip='127.0.0.3',
+                timestamp=datetime.utcnow(),
+                payload_digest=recorder.block_digest)
+            ru.dedup_info = dict(id=b'2', url=b'http://example.com/dup',
+                                 date=recent.strftime('%Y-%m-%dT%H:%M:%SZ').encode('utf-8'))
+            wwt.inq.put(ru)
+            assert recorded_url.warc_records
+            recorded_url = wwt.outq.get(timeout=10)
+            assert not recorded_url.warc_records
+            assert wwt.outq.empty()
+
         finally:
             wwt.stop.set()
             wwt.join()

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -166,8 +166,7 @@ def test_special_dont_write_prefix():
             recorder.read()
             old = datetime.utcnow() - timedelta(0, 3600)
             ru = RecordedUrl(
-                url='http://example.com/yes',
-                # content_type=hanzo.httptools.ResponseMessage.CONTENT_TYPE,
+                url='http://example.com/dup',
                 content_type='text/plain',
                 status=200, client_ip='127.0.0.2', request_data=b'abc',
                 response_recorder=recorder, remote_ip='127.0.0.3',
@@ -181,7 +180,7 @@ def test_special_dont_write_prefix():
             recorder.read()
             recent = datetime.utcnow() - timedelta(0, 5)
             ru = RecordedUrl(
-                url='http://example.com/yes', content_type='text/plain',
+                url='http://example.com/dup', content_type='text/plain',
                 status=200, client_ip='127.0.0.2', request_data=b'abc',
                 response_recorder=recorder, remote_ip='127.0.0.3',
                 timestamp=datetime.utcnow(),

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -158,6 +158,9 @@ def _build_arg_parser(prog='warcprox'):
     # Warcprox-Meta HTTP header. By default, we dedup all requests.
     arg_parser.add_argument('--dedup-only-with-bucket', dest='dedup_only_with_bucket',
                             action='store_true', default=False, help=argparse.SUPPRESS)
+    arg_parser.add_argument('--blackout-period', dest='blackout_period',
+                            type=int, default=0,
+                            help='skip writing a revisit record if its too close to the original capture')
     arg_parser.add_argument('--queue-size', dest='queue_size', type=int,
             default=500, help=argparse.SUPPRESS)
     arg_parser.add_argument('--max-threads', dest='max_threads', type=int,

--- a/warcprox/writerthread.py
+++ b/warcprox/writerthread.py
@@ -114,10 +114,6 @@ class WarcWriterProcessor(warcprox.BaseStandardPostfetchProcessor):
                   if recorded_url.warcprox_meta
                      and 'warc-prefix' in recorded_url.warcprox_meta
                   else self.options.prefix)
-        res = (prefix != '-' and not recorded_url.do_not_archive
-                and self._filter_accepts(recorded_url)
-                and not self._in_blackout(recorded_url))
-
         # special warc name prefix '-' means "don't archive"
         return (prefix != '-' and not recorded_url.do_not_archive
                 and self._filter_accepts(recorded_url)
@@ -132,7 +128,7 @@ class WarcWriterProcessor(warcprox.BaseStandardPostfetchProcessor):
         if self.blackout_period and hasattr(recorded_url, "dedup_info") and \
                 recorded_url.dedup_info:
             dedup_date = recorded_url.dedup_info.get('date')
-            if dedup_date:
+            if dedup_date and recorded_url.dedup_info.get('url') == recorded_url.url:
                 try:
                     dt = datetime.strptime(dedup_date.decode('utf-8'),
                                            '%Y-%m-%dT%H:%M:%SZ')


### PR DESCRIPTION
Add option `--blackout-period` (default=0)

When set and if the record is a duplicate (revisit record), check the
datetime of `dedup_info` and if its inside the `blackout_period`, skip
writing the record to WARC.

Add some unit tests.

This is an improved implementation based on @nlevitt comments here: https://github.com/internetarchive/warcprox/pull/92