### PR TITLE
Use in-memory LRU cache in CDX Server dedup

### DIFF
--- a/warcprox/dedup.py
+++ b/warcprox/dedup.py
@@ -237,8 +237,7 @@ class CdxServerDedup(DedupDb):
             headers['Cookie'] = options.cdxserver_dedup_cookies
         self.http_pool = urllib3.PoolManager(maxsize=maxsize, retries=0,
                                              timeout=2.0, headers=headers)
-        if options.cdxserver_dedup_lru_cache_size:
-            self.cached_lookup = lru_cache(maxsize=options.cdxserver_dedup_lru_cache_size)(self.lookup)
+        self.cached_lookup = lru_cache(maxsize=1024)(self.lookup)
 
     def loader(self, *args, **kwargs):
         return CdxServerDedupLoader(self, self.options)
@@ -302,7 +301,6 @@ class CdxServerDedupLoader(warcprox.BaseBatchPostfetchProcessor, DedupableMixin)
         self.pool = futures.ThreadPoolExecutor(max_workers=options.cdxserver_dedup_max_threads)
         self.batch = set()
         self.cdx_dedup = cdx_dedup
-        self.use_lru_cache = options.cdxserver_dedup_lru_cache_size != None
 
     def _get_process_put(self):
         recorded_url = self.inq.get(block=True, timeout=0.5)
@@ -319,11 +317,8 @@ class CdxServerDedupLoader(warcprox.BaseBatchPostfetchProcessor, DedupableMixin)
         try:
             digest_key = warcprox.digest_str(recorded_url.payload_digest,
                                              self.options.base32)
-            if self.use_lru_cache:
-                dedup_info = self.cdx_dedup.cached_lookup(digest_key, recorded_url.url)
-                self.logger.info(self.cdx_dedup.cached_lookup.cache_info())
-            else:
-                dedup_info = self.cdx_dedup.lookup(digest_key, recorded_url.url)
+            dedup_info = self.cdx_dedup.cached_lookup(digest_key, recorded_url.url)
+            self.logger.info(self.cdx_dedup.cached_lookup.cache_info())
             if dedup_info:
                 recorded_url.dedup_info = dedup_info
         except ValueError as exc:

--- a/warcprox/dedup.py
+++ b/warcprox/dedup.py
@@ -318,7 +318,9 @@ class CdxServerDedupLoader(warcprox.BaseBatchPostfetchProcessor, DedupableMixin)
             digest_key = warcprox.digest_str(recorded_url.payload_digest,
                                              self.options.base32)
             dedup_info = self.cdx_dedup.cached_lookup(digest_key, recorded_url.url)
-            self.logger.info(self.cdx_dedup.cached_lookup.cache_info())
+            cache_info = self.cdx_dedup.cached_lookup.cache_info()
+            if (cache_info.hits + cache_info.misses) % 1000 == 0:
+                self.logger.info(self.cdx_dedup.cached_lookup.cache_info())
             if dedup_info:
                 recorded_url.dedup_info = dedup_info
         except ValueError as exc:

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -172,10 +172,6 @@ def _build_arg_parser(prog='warcprox', show_hidden=False):
             '--cdxserver-dedup-max-threads', dest='cdxserver_dedup_max_threads',
             type=int, default=50, help=suppress(
                 'maximum number of cdx server dedup threads'))
-    hidden.add_argument(
-            '--cdxserver-dedup-lru-cache-size', dest='cdxserver_dedup_lru_cache_size',
-            type=int, default=1024, help=suppress(
-                'enable in-memory LRU cache to reduce duplicate CDX server requests'))
     arg_parser.add_argument('--dedup-min-text-size', dest='dedup_min_text_size',
                             type=int, default=0,
                             help=('try to dedup text resources with payload size over this limit in bytes'))

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -174,7 +174,7 @@ def _build_arg_parser(prog='warcprox', show_hidden=False):
                 'maximum number of cdx server dedup threads'))
     hidden.add_argument(
             '--cdxserver-dedup-lru-cache-size', dest='cdxserver_dedup_lru_cache_size',
-            type=int, help=suppress(
+            type=int, default=1024, help=suppress(
                 'enable in-memory LRU cache to reduce duplicate CDX server requests'))
     arg_parser.add_argument('--dedup-min-text-size', dest='dedup_min_text_size',
                             type=int, default=0,

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -172,6 +172,10 @@ def _build_arg_parser(prog='warcprox', show_hidden=False):
             '--cdxserver-dedup-max-threads', dest='cdxserver_dedup_max_threads',
             type=int, default=50, help=suppress(
                 'maximum number of cdx server dedup threads'))
+    hidden.add_argument(
+            '--cdxserver-dedup-lru-cache-size', dest='cdxserver_dedup_lru_cache_size',
+            type=int, help=suppress(
+                'enable in-memory LRU cache to reduce duplicate CDX server requests'))
     arg_parser.add_argument('--dedup-min-text-size', dest='dedup_min_text_size',
                             type=int, default=0,
                             help=('try to dedup text resources with payload size over this limit in bytes'))


### PR DESCRIPTION
Enable in-memory caching of CDX dedup requests using stdlib `lru_cache` method.
LRU Cache size is 1024.

Cache memory info is available on `INFO` logging outputs like:
```
CacheInfo(hits=3172, misses=3293, maxsize=1024, currsize=1024)
``