### PR TITLE
Add option to load logging conf from YAML file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ deps = [
     'PySocks>=1.6.8',
     'cryptography>=2.3',
     'idna>=2.5',
-    'PyYAML<=3.13',
+    'PyYAML>=5.1',
 ]
 try:
     import concurrent.futures

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ deps = [
     'PySocks>=1.6.8',
     'cryptography>=2.3',
     'idna>=2.5',
+    'PyYAML<=3.13',
 ]
 try:
     import concurrent.futures

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -309,7 +309,7 @@ def main(argv=None):
 
     if args.logging_conf_file:
         with open(args.logging_conf_file, 'r') as fd:
-            conf = yaml.load(fd)
+            conf = yaml.safe_load(fd)
             logging.config.dictConfig(conf)
 
     # see https://github.com/pyca/cryptography/issues/2911

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -29,7 +29,9 @@ try:
 except ImportError:
     import Queue as queue
 
+import json
 import logging
+import logging.config
 import sys
 import hashlib
 import argparse
@@ -240,6 +242,9 @@ def _build_arg_parser(prog='warcprox', show_hidden=False):
             '--trace', dest='trace', action='store_true',
             help='very verbose logging')
     arg_parser.add_argument(
+            '--logging-conf-file', dest='logging_conf_file', default=None,
+            help=('reads logging configuration from a JSON file'))
+    arg_parser.add_argument(
             '--version', action='version',
             version="warcprox {}".format(warcprox.__version__))
 
@@ -301,6 +306,11 @@ def main(argv=None):
             stream=sys.stdout, level=loglevel, format=(
                 '%(asctime)s %(process)d %(levelname)s %(threadName)s '
                 '%(name)s.%(funcName)s(%(filename)s:%(lineno)d) %(message)s'))
+
+    if args.logging_conf_file:
+        with open(args.logging_conf_file, 'r') as fd:
+            conf = json.load(fd)
+            logging.config.dictConfig(conf)
 
     # see https://github.com/pyca/cryptography/issues/2911
     cryptography.hazmat.backends.openssl.backend.activate_builtin_random()

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -29,7 +29,6 @@ try:
 except ImportError:
     import Queue as queue
 
-import json
 import logging
 import logging.config
 import sys
@@ -41,6 +40,7 @@ import traceback
 import signal
 import threading
 import certauth.certauth
+import yaml
 import warcprox
 import doublethink
 import cryptography.hazmat.backends.openssl
@@ -243,7 +243,7 @@ def _build_arg_parser(prog='warcprox', show_hidden=False):
             help='very verbose logging')
     arg_parser.add_argument(
             '--logging-conf-file', dest='logging_conf_file', default=None,
-            help=('reads logging configuration from a JSON file'))
+            help=('reads logging configuration from a YAML file'))
     arg_parser.add_argument(
             '--version', action='version',
             version="warcprox {}".format(warcprox.__version__))
@@ -309,7 +309,7 @@ def main(argv=None):
 
     if args.logging_conf_file:
         with open(args.logging_conf_file, 'r') as fd:
-            conf = json.load(fd)
+            conf = yaml.load(fd)
             logging.config.dictConfig(conf)
 
     # see https://github.com/pyca/cryptography/issues/2911


### PR DESCRIPTION
New option `--logging-conf-file` to load `logging` conf from a JSON
file.

Prefer JSON over the `configparser` format supported by
`logging.config.fileConfig` because JSON format is much better (nesting
is supported) and its easier to detect errors.