### PR TITLE
Avoid exception when trying to send error to client

### DIFF
--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -413,6 +413,8 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
         if hasattr(self, '_headers_buffer') and not self._headers_buffer:
             self._headers_buffer = []
         try:
+            if not self._sock:
+                return None
             return http_server.BaseHTTPRequestHandler.send_error(
                     self, code, message, explain)
         except:


### PR DESCRIPTION
When a request fails for any reason, we use
`MitmProxyHandler.send_error` to send an error response to the client.

The problem is that in many cases, there isn't an open socket connection
with the client any more, so we get a `BrokenPipeError`
`send_error(%r, %r, %r) raised exception`.

We just add a check to make sure that the socket connection with the client is
not None before trying to send the error.