### PR TITLE
Cache digest_str result in memory to improve performance

### DIFF
--- a/warcprox/__init__.py
+++ b/warcprox/__init__.py
@@ -27,6 +27,7 @@ import logging
 from argparse import Namespace as _Namespace
 from pkg_resources import get_distribution as _get_distribution
 import concurrent.futures
+from functools import lru_cache
 try:
     import queue
 except ImportError:
@@ -35,6 +36,7 @@ import json
 
 __version__ = _get_distribution('warcprox').version
 
+@lru_cache(maxsize=1024)
 def digest_str(hash_obj, base32=False):
     import base64
     return hash_obj.name.encode('utf-8') + b':' + (


### PR DESCRIPTION
We use `warcprox.digest_str` in 2 places during the course of a single
HTTP request. 1) In all `warcprox.dedup` methods to get the key and lookup for
duplicates, 2) in `warcprox.warc` to produce the WARC record.

We use `lru_cache` to avoid recalculating it.

We also reuse the cached result if the request for the same URL is done again.