### PR TITLE
Cache bad target hostname:port to avoid reconnection attempts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ deps = [
     'cryptography>=2.3',
     'idna>=2.5',
     'PyYAML>=5.1',
+    'cachetools',
 ]
 try:
     import concurrent.futures

--- a/tests/test_warcprox.py
+++ b/tests/test_warcprox.py
@@ -1986,6 +1986,10 @@ def test_socket_timeout_response(
 def test_empty_response(
         warcprox_, http_daemon, https_daemon, archiving_proxies,
         playback_proxies):
+    # localhost:server_port was added to the `bad_hostnames_ports` cache by
+    # previous tests and this causes subsequent tests to fail. We clear it.
+    warcprox_.proxy.bad_hostnames_ports.clear()
+
     url = 'http://localhost:%s/empty-response' % http_daemon.server_port
     response = requests.get(url, proxies=archiving_proxies, verify=False)
     assert response.status_code == 502
@@ -2001,6 +2005,10 @@ def test_payload_digest(warcprox_, http_daemon):
     Tests that digest is of RFC2616 "entity body"
     (transfer-decoded but not content-decoded)
     '''
+    # localhost:server_port was added to the `bad_hostnames_ports` cache by
+    # previous tests and this causes subsequent tests to fail. We clear it.
+    warcprox_.proxy.bad_hostnames_ports.clear()
+
     class HalfMockedMitm(warcprox.mitmproxy.MitmProxyHandler):
         def __init__(self, url):
             self.path = url

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -404,11 +404,11 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
             # subsequent reconnection attempts. `NewConnectionError` can be
             # caused by many types of errors which are handled by urllib3.
             if type(e) in (socket.timeout, NewConnectionError):
+                host_port = self._hostname_port_cache_key()
                 with self.server.bad_hostnames_ports_lock:
-                    host_port = self._hostname_port_cache_key()
                     self.server.bad_hostnames_ports[host_port] = 1
-                    self.logger.info('bad_hostnames_ports cache size: %d',
-                                     len(self.server.bad_hostnames_ports))
+                self.logger.info('bad_hostnames_ports cache size: %d',
+                                 len(self.server.bad_hostnames_ports))
             self.logger.error(
                     "problem processing request %r: %r",
                     self.requestline, e, exc_info=True)
@@ -555,11 +555,11 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
             # http_client._read_status(). In that case, the host is also bad
             # and we must add it to `bad_hostnames_ports` cache.
             if type(e) == http_client.RemoteDisconnected:
+                host_port = self._hostname_port_cache_key()
                 with self.server.bad_hostnames_ports_lock:
-                    host_port = self._hostname_port_cache_key()
                     self.server.bad_hostnames_ports[host_port] = 1
-                    self.logger.info('bad_hostnames_ports cache size: %d',
-                                     len(self.server.bad_hostnames_ports))
+                self.logger.info('bad_hostnames_ports cache size: %d',
+                                 len(self.server.bad_hostnames_ports))
 
             self._remote_server_conn.sock.shutdown(socket.SHUT_RDWR)
             self._remote_server_conn.sock.close()

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -549,12 +549,6 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
             if not is_connection_dropped(self._remote_server_conn):
                 self._conn_pool._put_conn(self._remote_server_conn)
         except Exception as e:
-            if type(e) in (socket.timeout, NewConnectionError):
-                with self.server.bad_hostnames_ports_lock:
-                    hostname_port = self._hostname_port_cache_key()
-                    self.server.bad_hostnames_ports[hostname_port] = 1
-                    self.logger.info('bad_hostnames_ports cache size: %d',
-                                     len(self.server.bad_hostnames_ports))
             self._remote_server_conn.sock.shutdown(socket.SHUT_RDWR)
             self._remote_server_conn.sock.close()
             raise

--- a/warcprox/playback.py
+++ b/warcprox/playback.py
@@ -42,6 +42,7 @@ from warcprox.mitmproxy import MitmProxyHandler
 import warcprox
 import sqlite3
 import threading
+from cachetools import TTLCache
 
 class PlaybackProxyHandler(MitmProxyHandler):
     logger = logging.getLogger("warcprox.playback.PlaybackProxyHandler")
@@ -219,6 +220,8 @@ class PlaybackProxy(socketserver.ThreadingMixIn, http_server.HTTPServer):
         self.playback_index_db = playback_index_db
         self.warcs_dir = options.directory
         self.options = options
+        self.bad_hostnames_ports = TTLCache(maxsize=1024, ttl=60)
+        self.bad_hostnames_ports_lock = threading.RLock()
 
     def server_activate(self):
         http_server.HTTPServer.server_activate(self)


### PR DESCRIPTION
If connection to a hostname:port fails, add it to a `TTLCache` with
60 sec expiration time. Subsequent requests to the same hostname:port
return really quickly as we check the cache and avoid trying a new
network connection.

The short expiration time guarantees that if a host becomes OK again,
we'll be able to connect to it quickly.

Adding `cachetools` dependency was necessary as there isn't any other
way to have an expiring in-memory cache using stdlib. The library
doesn't have any other dependencies, it has good test coverage and seems
maintained. It also supports Python 3.7.