### PR TITLE
Increase IO buffer size to improve WarcWriter performance

### DIFF
--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -57,6 +57,14 @@ except ImportError:
 # https://github.com/python/cpython/blob/3.7/Lib/http/client.py#L113
 http_client._MAXHEADERS = 7000
 
+# Default io buffer size is 8192 which is too small. We set it to 1MB improve
+# file writing performance.
+# https://github.com/python/cpython/blob/master/Modules/_io/_iomodule.c#L169
+# When we open a binary file to write, we use a BufferedWriter internally by
+# default, which uses DEFAULT_BUFFER_SIZE.
+import io
+io.DEFAULT_BUFFER_SIZE = 1048576
+
 import json
 import socket
 import logging

--- a/warcprox/writer.py
+++ b/warcprox/writer.py
@@ -148,7 +148,10 @@ class WarcWriter:
                     record.get_header(warctools.WarcRecord.CONTENT_LENGTH),
                     record.get_header(b'WARC-Payload-Digest'), record.offset,
                     self.path, record.get_header(warctools.WarcRecord.URL))
-        self.f.flush()
+        # We disable flush() and let the BufferedWriter flush when the buffer
+        # is full to improve performance. We increased `io.DEFAULT_BUFFER_SIZE
+        # to 1 MB to reduce disk flush frequency.
+        # self.f.flush()
         self.last_activity = time.time()
 
         return records


### PR DESCRIPTION
When we open a WARC file for writing with the standard `open(filename)` we
use a `BufferedWriter` to improve performance. This is the default python
behavior.

`BufferedWriter` uses `io.DEFAULT_BUFFER_SIZE=8192` by default unless we
set a custom value.

We set `io.DEFAULT_BUFFER_SIZE=1048576` (1 MB) to speed up file writing.
The buffer will be written out to the underlying `RawIOBase` object under
various conditions, including:

* when the buffer gets too small for all pending data;
* when flush() is called;
* when the BufferedWriter object is closed or destroyed.

https://docs.python.org/3/library/io.html#io.BufferedWriter

We remove the `flush()` command in the WARC writer.