### PR TITLE
Increase remote_connection_pool maxsize

### DIFF
--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -777,7 +777,7 @@ class SingleThreadedMitmProxy(http_server.HTTPServer):
         self.bad_hostnames_ports_lock = RLock()
 
         self.remote_connection_pool = PoolManager(
-            num_pools=max((options.max_threads or 0) // 6, 400))
+            num_pools=max((options.max_threads or 0) // 6, 400), maxsize=10)
 
         if options.onion_tor_socks_proxy:
             try:

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -777,7 +777,7 @@ class SingleThreadedMitmProxy(http_server.HTTPServer):
         self.bad_hostnames_ports_lock = RLock()
 
         self.remote_connection_pool = PoolManager(
-            num_pools=max((options.max_threads or 0) // 6, 400), maxsize=10)
+            num_pools=max((options.max_threads or 0) // 6, 400), maxsize=6)
 
         if options.onion_tor_socks_proxy:
             try:


### PR DESCRIPTION
We noticed a lot of log entries like this in production:
```
WARNING:urllib3.connectionpool:Connection pool is full, discarding
connection: static.xx.fbcdn.net
```
this happens because we use a `PoolManager` and create a number of pools
(param `num_pools`) but the number of connections each pool can have is
just 1 by default (param `maxsize` is 1 by default).

`urllib3` docs say: `maxsize` – Number of connections to save that can be
reused. More than 1 is useful in multithreaded situations.
Ref:
https://urllib3.readthedocs.io/en/1.2.1/pools.html#urllib3.connectionpool.HTTPConnectionPool

I suggest to use `maxsize=10` and re-evaluate after some time if its big
enough. (We'll see if we still get "Connection pool is full" warnings in the logs).

This improvement will boost performance as we'll reuse more connections
to remote hosts.