### PR TITLE
Handle ValueError when trying to close WARC file

### DIFF
--- a/warcprox/writer.py
+++ b/warcprox/writer.py
@@ -167,7 +167,7 @@ class WarcWriter:
             if self.open_suffix == '':
                 try:
                     fcntl.lockf(self.f, fcntl.LOCK_UN)
-                except (IOError, ValueError) as exc:
+                except Exception as exc:
                     self.logger.error(
                             'could not unlock file %s (%s)', self.path, exc)
             self.f.close()

--- a/warcprox/writer.py
+++ b/warcprox/writer.py
@@ -167,7 +167,7 @@ class WarcWriter:
             if self.open_suffix == '':
                 try:
                     fcntl.lockf(self.f, fcntl.LOCK_UN)
-                except IOError as exc:
+                except (IOError, ValueError) as exc:
                     self.logger.error(
                             'could not unlock file %s (%s)', self.path, exc)
             self.f.close()


### PR DESCRIPTION
We get a lot of the following error in production and warcprox becomes
totally unresponsive when this happens.
```
CRITICAL:warcprox.writerthread.WarcWriterProcessor:WarcWriterProcessor(tid=16646) will try to continue after unexpected error
Traceback (most recent call last):
  File "/opt/spn2/lib/python3.5/site-packages/warcprox/__init__.py", line 140, in _run
    self._get_process_put()
  File "/opt/spn2/lib/python3.5/site-packages/warcprox/writerthread.py", line 60, in _get_process_put
    self.writer_pool.maybe_idle_rollover()
  File "/opt/spn2/lib/python3.5/site-packages/warcprox/writer.py", line 233, in maybe_idle_rollover
    w.maybe_idle_rollover()
  File "/opt/spn2/lib/python3.5/site-packages/warcprox/writer.py", line 188, in maybe_idle_rollover
    self.close()
  File "/opt/spn2/lib/python3.5/site-packages/warcprox/writer.py", line 169, in close
    fcntl.lockf(self.f, fcntl.LOCK_UN)
ValueError: I/O operation on closed file
```

Current code handles `IOError`. We also need to handle `ValueError` to address this.