### PR TITLE
Avoid `UnicodeDecodeError` in Python 3.5, 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
         url='https://github.com/internetarchive/warcprox',
         author='Noah Levitt',
         author_email='nlevitt@archive.org',
-        long_description=open('README.rst').read(),
+        long_description=open('README.rst', encoding='utf-8').read(),
         license='GPL',
         packages=['warcprox'],
         install_requires=deps,


### PR DESCRIPTION
Trying to install `warcprox` in Python 3.5 or 3.6 (using `pip` or setup.py) I was hitting this error:
```
  File "setup.py", line 51, in <module>
    long_description=open('README.rst').read(),
  File "~/.virtualenvs/warcprox_36/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 2334: ordinal not in range(128)
```
I came across this while trying to make use of the [Vagrantfile](https://github.com/internetarchive/brozzler/blob/18d3f5f9300b8de16063157a67d52cfe32e41d9c/vagrant/Vagrantfile) in brozzler.

This minor change fixes the `UnicodeDecodeError` for me.