### PR TITLE
set failed_url.timestamp

### DIFF
--- a/warcprox/warcproxy.py
+++ b/warcprox/warcproxy.py
@@ -367,7 +367,7 @@ class WarcProxyHandler(warcprox.mitmproxy.MitmProxyHandler):
                 status=code,
                 client_ip=self.client_address[0],
                 method=self.command,
-                timestamp=None,
+                timestamp=doublethink.utcnow(),
                 host=self.hostname,
                 duration=None,
                 referer=self.headers.get('referer'),


### PR DESCRIPTION
and so avoid the occasional TypeError here:

https://github.com/internetarchive/warcprox/blob/f19ead00587633fe7e6ba6e3292456669755daaf/warcprox/controller.py#L169