### PR TITLE
in-batch dedup

### DIFF
--- a/warcprox/__init__.py
+++ b/warcprox/__init__.py
@@ -1,7 +1,7 @@
 """
 warcprox/__init__.py - warcprox package main file, contains some utility code
 
-Copyright (C) 2013-2019 Internet Archive
+Copyright (C) 2013-2021 Internet Archive
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -175,8 +175,8 @@ class BaseStandardPostfetchProcessor(BasePostfetchProcessor):
 
 class BaseBatchPostfetchProcessor(BasePostfetchProcessor):
     MAX_BATCH_SIZE = 500
-    MAX_BATCH_SEC = 10
-    MIN_BATCH_SEC = 2.0
+    MAX_BATCH_SEC = 30
+    MIN_BATCH_SEC = 10
 
     def _get_process_put(self):
         batch = []

--- a/warcprox/dedup.py
+++ b/warcprox/dedup.py
@@ -384,6 +384,9 @@ class BatchTroughStorer(warcprox.BaseBatchPostfetchProcessor):
                         self.trough_dedup_db.batch_save,
                         buckets[bucket], bucket)
                 fs[future] = bucket
+            logging.debug(
+                    'storing dedup info for %s urls '
+                    'in bucket %s', len(buckets[bucket]), bucket)
 
             # wait for results
             try:
@@ -434,6 +437,8 @@ class BatchTroughLoader(warcprox.BaseBatchPostfetchProcessor):
                         warcprox.digest_str(
                             recorded_url.payload_digest, self.options.base32)
                         if recorded_url.payload_digest else 'n/a')
+        self.logger.debug(
+                'hash_plus_urls: {}'.format(hash_plus_urls))
         self.logger.debug(
                 'len(batch)=%s len(discards)=%s buckets=%s',
                 len(batch), len(discards),

--- a/warcprox/dedup.py
+++ b/warcprox/dedup.py
@@ -435,7 +435,8 @@ class BatchTroughLoader(warcprox.BaseBatchPostfetchProcessor):
             else:
                 if hash_plus_url in hash_plus_urls:
                     self.logger.debug(
-                        'discarding duplicate {}'.format(hash_plus_url))
+                        'discarding duplicate {}, setting do_not_archive'.format(hash_plus_url))
+                    recorded_url.do_not_archive = True
                 discards.append(
                         warcprox.digest_str(
                             recorded_url.payload_digest, self.options.base32)

--- a/warcprox/dedup.py
+++ b/warcprox/dedup.py
@@ -419,8 +419,8 @@ class BatchTroughLoader(warcprox.BaseBatchPostfetchProcessor):
         hash_plus_urls = set()
         for recorded_url in batch:
             if recorded_url.payload_digest:
-                hash_plus_url = ''.join((warcprox.digest_str(
-                            recorded_url.payload_digest, self.options.base32), recorded_url.url.decode()))
+                hash_plus_url = b''.join((warcprox.digest_str(
+                            recorded_url.payload_digest, self.options.base32), recorded_url.url))
             if (recorded_url.response_recorder
                     and recorded_url.payload_digest
                     and self.trough_dedup_db.should_dedup(recorded_url)
@@ -441,7 +441,7 @@ class BatchTroughLoader(warcprox.BaseBatchPostfetchProcessor):
                             recorded_url.payload_digest, self.options.base32)
                         if recorded_url.payload_digest else 'n/a')
         self.logger.debug(
-                'hash_plus_urls: {}...'.format(hash_plus_urls[0]))
+                'hash_plus_urls: {}'.format(len(hash_plus_urls)))
         self.logger.debug(
                 'len(batch)=%s len(discards)=%s buckets=%s',
                 len(batch), len(discards),

--- a/warcprox/dedup.py
+++ b/warcprox/dedup.py
@@ -424,7 +424,7 @@ class BatchTroughLoader(warcprox.BaseBatchPostfetchProcessor):
             if (recorded_url.response_recorder
                     and recorded_url.payload_digest
                     and self.trough_dedup_db.should_dedup(recorded_url)
-                    and '{}{}'.format(recorded_url.payload_digest, recorded_url.url) not in hash_plus_urls):
+                    and hash_plus_url not in hash_plus_urls):
                 hash_plus_urls.add(hash_plus_url)
                 if (recorded_url.warcprox_meta
                         and 'dedup-buckets' in recorded_url.warcprox_meta):
@@ -435,13 +435,13 @@ class BatchTroughLoader(warcprox.BaseBatchPostfetchProcessor):
             else:
                 if hash_plus_url in hash_plus_urls:
                     self.logger.debug(
-                        'discarding duplicate {}'.format(hash_plus_url)
+                        'discarding duplicate {}'.format(hash_plus_url))
                 discards.append(
                         warcprox.digest_str(
                             recorded_url.payload_digest, self.options.base32)
                         if recorded_url.payload_digest else 'n/a')
         self.logger.debug(
-                'hash_plus_urls: {}'.format(hash_plus_urls))
+                'hash_plus_urls: {}...'.format(hash_plus_urls[0]))
         self.logger.debug(
                 'len(batch)=%s len(discards)=%s buckets=%s',
                 len(batch), len(discards),

--- a/warcprox/dedup.py
+++ b/warcprox/dedup.py
@@ -418,8 +418,8 @@ class BatchTroughLoader(warcprox.BaseBatchPostfetchProcessor):
             if (recorded_url.response_recorder
                     and recorded_url.payload_digest
                     and self.trough_dedup_db.should_dedup(recorded_url)
-                    and f'{recorded_url.payload_digest}{recorded_url.url}' not in hash_plus_urls):
-                hash_plus_urls.add(f'{recorded_url.payload_digest}{recorded_url.url}')
+                    and '{}{}'.format(recorded_url.payload_digest, recorded_url.url) not in hash_plus_urls):
+                hash_plus_urls.add('{}{}'.format(recorded_url.payload_digest, recorded_url.url))
                 if (recorded_url.warcprox_meta
                         and 'dedup-buckets' in recorded_url.warcprox_meta):
                     for bucket, bucket_mode in recorded_url.warcprox_meta["dedup-buckets"].items():
@@ -427,9 +427,9 @@ class BatchTroughLoader(warcprox.BaseBatchPostfetchProcessor):
                 else:
                     buckets['__unspecified__'].append(recorded_url)
             else:
-                if f'{recorded_url.payload_digest}{recorded_url.url}' in hash_plus_urls:
+                if recorded_url.payload_digest and '{}{}'.format(recorded_url.payload_digest, recorded_url.url) in hash_plus_urls:
                     self.logger.debug(
-                        f'discarding duplicate {recorded_url.payload_digest} {recorded_url.url}')
+                        'discarding duplicate {} {}'.format(recorded_url.payload_digest, recorded_url.url))
                 discards.append(
                         warcprox.digest_str(
                             recorded_url.payload_digest, self.options.base32)

--- a/warcprox/dedup.py
+++ b/warcprox/dedup.py
@@ -435,14 +435,14 @@ class BatchTroughLoader(warcprox.BaseBatchPostfetchProcessor):
             else:
                 if hash_plus_url in hash_plus_urls:
                     self.logger.debug(
-                        'discarding duplicate {}, setting do_not_archive'.format(hash_plus_url))
+                        'discarding duplicate and setting do_not_archive for %, hash %'.format(
+                            recorded_url.url, warcprox.digest_str(
+                            recorded_url.payload_digest, self.options.base32)))
                     recorded_url.do_not_archive = True
                 discards.append(
                         warcprox.digest_str(
                             recorded_url.payload_digest, self.options.base32)
                         if recorded_url.payload_digest else 'n/a')
-        self.logger.debug(
-                'hash_plus_urls: {}'.format(len(hash_plus_urls)))
         self.logger.debug(
                 'len(batch)=%s len(discards)=%s buckets=%s',
                 len(batch), len(discards),


### PR DESCRIPTION
Many duplicate captures in brozzler crawls are due to no dedup within dedup batches.  This MR adds in-batch dedup for trough deduplication, and increases warcprox's dedup batch window.