### PR TITLE
GitHub Action to lint Python

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,23 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: pip install --user codespell ruff
+      - run: ruff --format=github --line-length=388 --target-version=py37
+                  --ignore=E401,E402,E701,E702,E722,E741,F401,F811,F821,F841 .
+      - run: codespell --ignore-words-list="anull,trough" --skip="./.*"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: pip install --upgrade pip setuptools wheel
+      - run: pip install black mypy pytest safety
+      - run: black --check . || true
+      - run: pip install --editable .
+      - run: pip install aiohttp mock warcio
+      - run: mkdir --parents --verbose .mypy_cache
+      - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
+      - run: pytest
+      - run: safety check

--- a/tests/test_warcprox.py
+++ b/tests/test_warcprox.py
@@ -920,8 +920,8 @@ def test_dedup_buckets(https_daemon, http_daemon, warcprox_, archiving_proxies, 
         assert record.type == b'request'
 
         # that's all folks
-        assert next(record_iter)[1] == None
-        assert next(record_iter, None) == None
+        assert next(record_iter)[1] is None
+        assert next(record_iter, None) is None
 
     finally:
         fh.close()
@@ -985,8 +985,8 @@ def test_dedup_buckets_readonly(https_daemon, http_daemon, warcprox_, archiving_
         assert record.type == b'request'
 
         # that's all folks
-        assert next(record_iter)[1] == None
-        assert next(record_iter, None) == None
+        assert next(record_iter)[1] is None
+        assert next(record_iter, None) is None
 
     finally:
         fh.close()
@@ -1457,7 +1457,7 @@ def test_missing_content_length(archiving_proxies, http_daemon, https_daemon, wa
     response = requests.get(url, verify=False, timeout=10)
     assert response.content == (
             b'This response is missing a Content-Length http header.')
-    assert not 'content-length' in response.headers
+    assert 'content-length' not in response.headers
 
     # double-check that our test https server is responding as expected
     url = 'https://localhost:%s/missing-content-length' % (
@@ -1465,7 +1465,7 @@ def test_missing_content_length(archiving_proxies, http_daemon, https_daemon, wa
     response = requests.get(url, verify=False, timeout=10)
     assert response.content == (
             b'This response is missing a Content-Length http header.')
-    assert not 'content-length' in response.headers
+    assert 'content-length' not in response.headers
 
     # now check that the proxy doesn't hang (http)
     url = 'http://localhost:%s/missing-content-length' % (
@@ -1474,7 +1474,7 @@ def test_missing_content_length(archiving_proxies, http_daemon, https_daemon, wa
             url, proxies=archiving_proxies, verify=False, timeout=10)
     assert response.content == (
             b'This response is missing a Content-Length http header.')
-    assert not 'content-length' in response.headers
+    assert 'content-length' not in response.headers
 
     # now check that the proxy doesn't hang (https)
     url = 'https://localhost:%s/missing-content-length' % (
@@ -1485,7 +1485,7 @@ def test_missing_content_length(archiving_proxies, http_daemon, https_daemon, wa
             url, proxies=archiving_proxies, verify=False, timeout=10)
     assert response.content == (
             b'This response is missing a Content-Length http header.')
-    assert not 'content-length' in response.headers
+    assert 'content-length' not in response.headers
 
     # wait for postfetch chain
     wait(lambda: warcprox_.proxy.running_stats.urls - urls_before == 2, timeout=20)
@@ -1619,8 +1619,8 @@ def test_dedup_ok_flag(
                             'timestamp').run()
     results = list(results_iter)
     assert len(results) == 2
-    assert results[0].get('dedup_ok') == False
-    assert not 'dedup_ok' in results[1]
+    assert results[0].get('dedup_ok') is False
+    assert 'dedup_ok' not in results[1]
     assert results[0]['url'] == url
     assert results[1]['url'] == url
     assert results[0]['warc_type'] == 'response'
@@ -1784,7 +1784,7 @@ def test_via_response_header(warcprox_, http_daemon, archiving_proxies, playback
     playback_response = requests.get(
             url, proxies=playback_proxies, verify=False)
     assert response.status_code == 200
-    assert not 'via' in playback_response
+    assert 'via' not in playback_response
 
     warc = warcprox_.warc_writer_processor.writer_pool.default_warc_writer.path
     with open(warc, 'rb') as f:
@@ -2143,7 +2143,7 @@ def test_crawl_log(warcprox_, http_daemon, archiving_proxies):
 
 def test_crawl_log_canonicalization():
     assert crawl_log.canonicalize_url(None) is None
-    assert crawl_log.canonicalize_url("") is ''
+    assert crawl_log.canonicalize_url("") == ''
     assert crawl_log.canonicalize_url("-") == '-'
     assert crawl_log.canonicalize_url("http://чунджа.kz/b/¶-non-ascii") == "http://xn--80ahg0a3ax.kz/b/%C2%B6-non-ascii"
     assert crawl_log.canonicalize_url("Not a URL") == "Not a URL"

--- a/warcprox/bigtable.py
+++ b/warcprox/bigtable.py
@@ -99,11 +99,11 @@ class RethinkCaptures:
 
     def _ensure_db_table(self):
         dbs = self.rr.db_list().run()
-        if not self.rr.dbname in dbs:
+        if self.rr.dbname not in dbs:
             self.logger.info("creating rethinkdb database %r", self.rr.dbname)
             self.rr.db_create(self.rr.dbname).run()
         tables = self.rr.table_list().run()
-        if not self.table in tables:
+        if self.table not in tables:
             self.logger.info(
                     "creating rethinkdb table %r in database %r",
                     self.table, self.rr.dbname)

--- a/warcprox/controller.py
+++ b/warcprox/controller.py
@@ -280,7 +280,7 @@ class WarcproxController(object):
             for obj in all_objects:
                 size = sys.getsizeof(obj)
                 total_size += size
-                if not type(obj) in summary:
+                if type(obj) not in summary:
                     summary[type(obj)] = {"count":0,"size":0}
                 summary[type(obj)]["count"] += 1
                 summary[type(obj)]["size"] += size

--- a/warcprox/dedup.py
+++ b/warcprox/dedup.py
@@ -179,11 +179,11 @@ class RethinkDedupDb(DedupDb, DedupableMixin):
 
     def _ensure_db_table(self):
         dbs = self.rr.db_list().run()
-        if not self.rr.dbname in dbs:
+        if self.rr.dbname not in dbs:
             self.logger.info("creating rethinkdb database %r", self.rr.dbname)
             self.rr.db_create(self.rr.dbname).run()
         tables = self.rr.table_list().run()
-        if not self.table in tables:
+        if self.table not in tables:
             self.logger.info(
                     "creating rethinkdb table %r in database %r shards=%r "
                     "replicas=%r", self.table, self.rr.dbname,

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -596,7 +596,7 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
                             'bytes exceeded for URL %s',
                             self._max_resource_size, self.url)
                     break
-                elif (not 'content-length' in self.headers
+                elif ('content-length' not in self.headers
                         and time.time() - start > 3 * 60 * 60):
                     prox_rec_res.truncated = b'time'
                     self._remote_server_conn.sock.shutdown(socket.SHUT_RDWR)

--- a/warcprox/stats.py
+++ b/warcprox/stats.py
@@ -80,7 +80,7 @@ def unravel_buckets(url, warcprox_meta):
             and "buckets" in warcprox_meta["stats"]):
         for bucket in warcprox_meta["stats"]["buckets"]:
             if isinstance(bucket, dict):
-                if not 'bucket' in bucket:
+                if 'bucket' not in bucket:
                     self.logger.warning(
                             'ignoring invalid stats bucket in '
                             'warcprox-meta header %s', bucket)
@@ -221,12 +221,12 @@ class RethinkStatsProcessor(StatsProcessor):
 
     def _ensure_db_table(self):
         dbs = self.rr.db_list().run()
-        if not self.rr.dbname in dbs:
+        if self.rr.dbname not in dbs:
             self.logger.info(
                     "creating rethinkdb database %r", self.rr.dbname)
             self.rr.db_create(self.rr.dbname).run()
         tables = self.rr.table_list().run()
-        if not self.table in tables:
+        if self.table not in tables:
             self.logger.info(
                     "creating rethinkdb table %r in database %r shards=%r "
                     "replicas=%r", self.table, self.rr.dbname, 1,

--- a/warcprox/warcproxy.py
+++ b/warcprox/warcproxy.py
@@ -109,7 +109,7 @@ class WarcProxyHandler(warcprox.mitmproxy.MitmProxyHandler):
             bucket0 = "%s:%s" % (b, domain)
             limit_key = "%s/%s/%s" % (bucket0, bucket1, bucket2)
 
-        if not bucket0 in buckets:
+        if bucket0 not in buckets:
             return
 
         value = self.server.stats_db.value(bucket0, bucket1, bucket2)

--- a/warcprox/writer.py
+++ b/warcprox/writer.py
@@ -217,7 +217,7 @@ class WarcWriterPool:
             # self.logger.info("recorded_url.warcprox_meta={} for {}".format(recorded_url.warcprox_meta, recorded_url.url))
             options = warcprox.Options(**vars(self.options))
             options.prefix = recorded_url.warcprox_meta["warc-prefix"]
-            if not options.prefix in self.warc_writers:
+            if options.prefix not in self.warc_writers:
                 self.warc_writers[options.prefix] = WarcWriter(options)
             w = self.warc_writers[options.prefix]
         return w


### PR DESCRIPTION
Confirm that `bandit`, `codespell`, `flake8`, `pytest`, and `safety` pass on all pull requests.

Test results: https://github.com/cclauss/warcprox/actions

The last Travis CI run was a year ago... https://travis-ci.org/github/internetarchive/warcprox/builds

============================= test session starts ==============================
platform linux -- Python 3.10.5, pytest-7.1.2, pluggy-1.0.0 -- /opt/hostedtoolcache/Python/3.10.5/x64/bin/python
cachedir: .pytest_cache
rootdir: /home/runner/work/warcprox/warcprox, configfile: setup.cfg, testpaths: tests
collecting ... collected 42 items
tests/test_dedup.py::test_cdx_dedup PASSED                               [  2%]
tests/test_ensure_rethinkdb_tables.py::test_individual_options SKIPPED   [  4%]
tests/test_ensure_rethinkdb_tables.py::test_combos SKIPPED (rethinkd...) [  7%]
tests/test_warcprox.py::test_httpds_no_proxy PASSED                      [  9%]
tests/test_warcprox.py::test_archive_and_playback_http_url PASSED        [ 11%]
tests/test_warcprox.py::test_archive_and_playback_https_url PASSED       [ 14%]
tests/test_warcprox.py::test_dedup_http PASSED                           [ 16%]
tests/test_warcprox.py::test_dedup_https PASSED                          [ 19%]
tests/test_warcprox.py::test_limits PASSED                               [ 21%]
tests/test_warcprox.py::test_return_capture_timestamp PASSED             [ 23%]
tests/test_warcprox.py::test_dedup_buckets PASSED                        [ 26%]
tests/test_warcprox.py::test_dedup_buckets_readonly PASSED               [ 28%]
tests/test_warcprox.py::test_dedup_bucket_concurrency PASSED             [ 30%]
tests/test_warcprox.py::test_block_rules PASSED                          [ 33%]
tests/test_warcprox.py::test_domain_doc_soft_limit PASSED                [ 35%]
tests/test_warcprox.py::test_domain_data_soft_limit PASSED               [ 38%]
tests/test_warcprox.py::test_tor_onion XFAIL                             [ 40%]
tests/test_warcprox.py::test_missing_content_length PASSED               [ 42%]
tests/test_warcprox.py::test_limit_large_resource PASSED                 [ 45%]
tests/test_warcprox.py::test_method_filter PASSED                        [ 47%]
tests/test_warcprox.py::test_dedup_ok_flag PASSED                        [ 50%]
tests/test_warcprox.py::test_status_api PASSED                           [ 52%]
tests/test_warcprox.py::test_svcreg_status PASSED                        [ 54%]
tests/test_warcprox.py::test_controller_with_defaults PASSED             [ 57%]
tests/test_warcprox.py::test_load_plugin PASSED                          [ 59%]
tests/test_warcprox.py::test_choose_a_port_for_me PASSED                 [ 61%]
tests/test_warcprox.py::test_via_response_header PASSED                  [ 64%]
tests/test_warcprox.py::test_slash_in_warc_prefix PASSED                 [ 66%]
tests/test_warcprox.py::test_crawl_log PASSED                            [ 69%]
tests/test_warcprox.py::test_crawl_log_canonicalization PASSED           [ 71%]
tests/test_warcprox.py::test_long_warcprox_meta PASSED                   [ 73%]
tests/test_warcprox.py::test_socket_timeout_response PASSED              [ 76%]
tests/test_warcprox.py::test_empty_response PASSED                       [ 78%]
tests/test_warcprox.py::test_payload_digest PASSED                       [ 80%]
tests/test_warcprox.py::test_dedup_min_text_size PASSED                  [ 83%]
tests/test_warcprox.py::test_dedup_min_binary_size PASSED                [ 85%]
tests/test_warcprox.py::test_incomplete_read PASSED                      [ 88%]
tests/test_writer.py::test_warc_writer_locking PASSED                    [ 90%]
tests/test_writer.py::test_special_dont_write_prefix PASSED              [ 92%]
tests/test_writer.py::test_do_not_archive PASSED                         [ 95%]
tests/test_writer.py::test_warc_writer_filename PASSED                   [ 97%]
tests/test_writer.py::test_close_for_prefix PASSED                       [100%]
============ 39 passed, 2 skipped, 1 xfailed, 71 warnings in 53.28s ===========