### PR TITLE
GitHub Action to run pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,5 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: pip install --user aiohttp mock pytest warcio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: pip install aiohttp mock pytest warcio
+      - run: pip install --editable .
       - run: pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,5 +9,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: pip install --user pytest
+      - run: pip install --user aiohttp mock pytest warcio
       - run: pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,13 @@
+name: pytest
+on:
+  push:
+  #  branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: pip install --user pytest
+      - run: pytest


### PR DESCRIPTION
A subset of #181 that only focuses on running pytest.

Test results: https://github.com/cclauss/warcprox/actions

% `pytest`
```
============================= test session starts ==============================
platform linux -- Python 3.11.3, pytest-7.3.1, pluggy-1.0.0 -- /opt/hostedtoolcache/Python/3.11.3/x64/bin/python
collecting ... collected 42 items

tests/test_dedup.py::test_cdx_dedup PASSED                               [  2%]
tests/test_ensure_rethinkdb_tables.py::test_individual_options SKIPPED   [  4%]
tests/test_ensure_rethinkdb_tables.py::test_combos SKIPPED (rethinkd...) [  7%]
tests/test_warcprox.py::test_httpds_no_proxy PASSED                      [  9%]
tests/test_warcprox.py::test_archive_and_playback_http_url PASSED        [ 11%]
tests/test_warcprox.py::test_archive_and_playback_https_url PASSED       [ 14%]
tests/test_warcprox.py::test_dedup_http PASSED                           [ 16%]
tests/test_warcprox.py::test_dedup_https PASSED                          [ 19%]
tests/test_warcprox.py::test_limits PASSED                               [ 21%]
tests/test_warcprox.py::test_return_capture_timestamp PASSED             [ 23%]
tests/test_warcprox.py::test_dedup_buckets PASSED                        [ 26%]
tests/test_warcprox.py::test_dedup_buckets_readonly PASSED               [ 28%]
tests/test_warcprox.py::test_dedup_bucket_concurrency PASSED             [ 30%]
tests/test_warcprox.py::test_block_rules PASSED                          [ 33%]
tests/test_warcprox.py::test_domain_doc_soft_limit PASSED                [ 35%]
tests/test_warcprox.py::test_domain_data_soft_limit PASSED               [ 38%]
tests/test_warcprox.py::test_tor_onion XFAIL                             [ 40%]
tests/test_warcprox.py::test_missing_content_length PASSED               [ 42%]
tests/test_warcprox.py::test_limit_large_resource PASSED                 [ 45%]
tests/test_warcprox.py::test_method_filter PASSED                        [ 47%]
tests/test_warcprox.py::test_dedup_ok_flag PASSED                        [ 50%]
tests/test_warcprox.py::test_status_api PASSED                           [ 52%]
tests/test_warcprox.py::test_svcreg_status PASSED                        [ 54%]
tests/test_warcprox.py::test_controller_with_defaults PASSED             [ 57%]
tests/test_warcprox.py::test_load_plugin PASSED                          [ 59%]
tests/test_warcprox.py::test_choose_a_port_for_me PASSED                 [ 61%]
tests/test_warcprox.py::test_via_response_header PASSED                  [ 64%]
tests/test_warcprox.py::test_slash_in_warc_prefix PASSED                 [ 66%]
tests/test_warcprox.py::test_crawl_log PASSED                            [ 69%]
tests/test_warcprox.py::test_crawl_log_canonicalization PASSED           [ 71%]
tests/test_warcprox.py::test_long_warcprox_meta PASSED                   [ 73%]
tests/test_warcprox.py::test_socket_timeout_response PASSED              [ 76%]
tests/test_warcprox.py::test_empty_response PASSED                       [ 78%]
tests/test_warcprox.py::test_payload_digest PASSED                       [ 80%]
tests/test_warcprox.py::test_dedup_min_text_size PASSED                  [ 83%]
tests/test_warcprox.py::test_dedup_min_binary_size PASSED                [ 85%]
tests/test_warcprox.py::test_incomplete_read PASSED                      [ 88%]
tests/test_writer.py::test_warc_writer_locking PASSED                    [ 90%]
tests/test_writer.py::test_special_dont_write_prefix PASSED              [ 92%]
tests/test_writer.py::test_do_not_archive PASSED                         [ 95%]
tests/test_writer.py::test_warc_writer_filename PASSED                   [ 97%]
tests/test_writer.py::test_close_for_prefix PASSED                       [100%]

============ 39 passed, 2 skipped, 1 xfailed, 71 warnings in 52.30s ============
```