### PR TITLE
GitHub Action to run pytest on the qa branch

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,17 @@
+name: pytest
+on:
+  push:
+  #  branches: [master, qa]
+  pull_request:
+    branches: [master, qa]
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: pip install aiohttp mock pytest warcio
+      - run: pip install --editable .
+      - run: pytest

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ except:
 
 setuptools.setup(
         name='warcprox',
-        version='2.4.32.qa',
+        version='2.4.32.dev0',
         description='WARC writing MITM HTTP/S proxy',
         url='https://github.com/internetarchive/warcprox',
         author='Noah Levitt',


### PR DESCRIPTION
Like #182 but on the `qa` branch instead of the `master` branch.

Test results: https://github.com/cclauss/warcprox/actions
> Version '2.4.32.qa' is not valid according to PEP 440.

Fixed with `setuptools.setup(version='2.4.32.dev0')`.

> ============================= test session starts ==============================
> platform linux -- Python 3.11.3, pytest-7.3.2, pluggy-1.0.0 -- /opt/hostedtoolcache/Python/3.11.3/x64/bin/python
> [ ... ]
> tests/test_warcprox.py::test_limit_large_resource FAILED                 [ 45%]
> tests/test_warcprox.py::test_method_filter FAILED                        [ 47%]
> [ ... ]
> == 2 failed, 37 passed, 2 skipped, 1 xfailed, 71 warnings in 61.97s (0:01:01) ==
