### PR TITLE
Limit dependency version cryptography>=2.3,<=39.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ deps = [
     'urllib3>=1.23',
     'requests>=2.0.1',
     'PySocks>=1.6.8',
-    'cryptography>=2.3',
+    'cryptography>=2.3,<=39.0.0',
     'idna==2.10',
     'PyYAML>=5.1',
     'cachetools',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ deps = [
     'urllib3>=1.23',
     'requests>=2.0.1',
     'PySocks>=1.6.8',
-    'cryptography>=2.3,<=39.0.0',
+    'cryptography>=2.3,<40',
     'idna==2.10',
     'PyYAML>=5.1',
     'cachetools',


### PR DESCRIPTION
cryptography 41.0.0 crashes warcprox with the following exception:
```
File "/opt/spn2/lib/python3.8/site-packages/warcprox/main.py", line 317, in main
  cryptography.hazmat.backends.openssl.backend.activate_builtin_random()
AttributeError: 'Backend' object has no attribute 'activate_builtin_random'
```

Also, cryptography==40.0.0 isn't OK because when I try to use it I get:
```
pyopenssl 23.2.0 requires cryptography!=40.0.0,!=40.0.1,<42,>=38.0.0, but you have cryptography 40.0.0 which is incompatible.
```

So, the version should be <=39.0.0