### PR TITLE
Drop idna==2.10 version lock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ deps = [
     'requests>=2.0.1',
     'PySocks>=1.6.8',
     'cryptography>=2.3,<40',
-    'idna==2.10',
+    'idna',
     'PyYAML>=5.1',
     'cachetools',
     'rfc3986>=1.5.0',


### PR DESCRIPTION
There is no need to use such an old `idna` version. The latest works with py35+ and all tests pass.
Newer `idna` supports the latest Unicode standard and latest python versions.
https://github.com/kjd/idna/blob/master/HISTORY.rst