### PR TITLE
New option --subdir-prefix

### DIFF
--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -91,6 +91,8 @@ def _build_arg_parser(prog='warcprox', show_hidden=False):
             help='where to store and load generated certificates')
     arg_parser.add_argument('-d', '--dir', dest='directory',
             default='./warcs', help='where to write warcs')
+    arg_parser.add_argument('--subdir-prefix', dest='subdir_prefix', action='store_true',
+                            help='write warcs to --dir subdir equal to the current warc-prefix'),
     arg_parser.add_argument('--warc-filename', dest='warc_filename',
             default='{prefix}-{timestamp17}-{serialno}-{randomtoken}',
             help='define custom WARC filename with variables {prefix}, {timestamp14}, {timestamp17}, {serialno}, {randomtoken}, {hostname}, {shorthostname}, {port}')

--- a/warcprox/writer.py
+++ b/warcprox/writer.py
@@ -55,7 +55,10 @@ class WarcWriter:
         self.open_suffix = '' if options.no_warc_open_suffix else '.open'
         self.rollover_size = options.rollover_size or 1000000000
         self.rollover_idle_time = options.rollover_idle_time or None
-        self.directory = options.directory or './warcs'
+        if options.subdir_prefix and options.prefix:
+            self.directory = os.path.sep.join([options.directory, options.prefix]) or './warcs'
+        else:
+            self.directory = options.directory or './warcs'
         self.filename_template = options.warc_filename or \
                 '{prefix}-{timestamp17}-{randomtoken}-{serialno}'
         self.last_activity = time.time()


### PR DESCRIPTION
Save WARCs in subdirectories equal to the current value of `Warcprox-Meta['warc-prefix']`. E.g. if `warc-prefix=='spn2'` and `--dir=/warcs`, save them in `/warcs/spn2/`.