### PR TITLE
Upgrade cryptography dependency to >=39,<40

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ deps = [
     'urllib3>=1.23',
     'requests>=2.0.1',
     'PySocks>=1.6.8',
-    'cryptography>=2.3,<40',
+    'cryptography>=39,<40',
     'idna',
     'PyYAML>=5.1',
     'cachetools',


### PR DESCRIPTION
warcprox crashes with the following error when using `cryptography==35.0.0`.

```
ValueError: Valid PEM but no BEGIN CERTIFICATE/END CERTIFICATE delimiters. Are you sure this is a certificate?
Traceback (most recent call last):
  File "/opt/spn2/bin/warcprox", line 8, in <module>
    sys.exit(main())
  File "/opt/spn2/lib/python3.8/site-packages/warcprox/main.py", line 330, in main
    controller = warcprox.controller.WarcproxController(options)
  File "/opt/spn2/lib/python3.8/site-packages/warcprox/controller.py", line 145, in __init__
    self.proxy = warcprox.warcproxy.WarcProxy(
  File "/opt/spn2/lib/python3.8/site-packages/warcprox/warcproxy.py", line 561, in __init__
    SingleThreadedWarcProxy.__init__(
  File "/opt/spn2/lib/python3.8/site-packages/warcprox/warcproxy.py", line 509, in __init__
    warcprox.mitmproxy.SingleThreadedMitmProxy.__init__(
  File "/opt/spn2/lib/python3.8/site-packages/warcprox/mitmproxy.py", line 861, in __init__
    self.ca = CertificateAuthority(
  File "/opt/spn2/lib/python3.8/site-packages/warcprox/certauth.py", line 69, in __init__
    self.cert, self.key = self.read_pem(ca_file)
  File "/opt/spn2/lib/python3.8/site-packages/warcprox/certauth.py", line 210, in read_pem
    cert = x509.load_pem_x509_certificate(f.read(), default_backend())
  File "/opt/spn2/lib/python3.8/site-packages/cryptography/x509/base.py", line 436, in load_pem_x509_certificate
    return rust_x509.load_pem_x509_certificate(data)
ValueError: Valid PEM but no BEGIN CERTIFICATE/END CERTIFICATE delimiters. Are you sure this is a certificate?
```