### PR TITLE
Postfetch processor for filtering results by MIME type specified in HTTP response Content-Type

### DIFF
--- a/api.rst
+++ b/api.rst
@@ -197,8 +197,10 @@ There are two expected keys in a MIME type filter block:
 
 * ``regex``: A regex expression to be applied to the Content-Type header value.
 * ``type``: The type of filtering logic to apply. Two values are supported.
-  * ``REJECT``: Any Content-Type header value matching the regex will be rejected.
-  * ``LIMIT``: Only Content-Type values matching the regex will be allowed.
+
+Valid values for ``type`` key:
+* ``REJECT``: Any Content-Type header value matching the regex will be rejected.
+* ``LIMIT``: Only Content-Type values matching the regex will be allowed.
 
 ``stats`` (dictionary)
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/api.rst
+++ b/api.rst
@@ -197,8 +197,7 @@ There are two expected keys in a MIME type filter block:
 
 * ``regex``: A regex expression to be applied to the Content-Type header value.
 * ``type``: The type of filtering logic to apply. Two values are supported.
-  * ``REJECT``: Any Content-Type header value matching the regex will be
-    rejected.
+  * ``REJECT``: Any Content-Type header value matching the regex will be rejected.
   * ``LIMIT``: Only Content-Type values matching the regex will be allowed.
 
 ``stats`` (dictionary)

--- a/api.rst
+++ b/api.rst
@@ -199,6 +199,7 @@ There are two expected keys in a MIME type filter block:
 * ``type``: The type of filtering logic to apply. Two values are supported.
 
 Valid values for ``type`` key:
+
 * ``REJECT``: Any Content-Type header value matching the regex will be rejected.
 * ``LIMIT``: Only Content-Type values matching the regex will be allowed.
 

--- a/api.rst
+++ b/api.rst
@@ -186,6 +186,21 @@ to evaluate the block rules. In particular, this circumstance prevails when the
 browser controlled by brozzler is requesting images, javascript, css, and so
 on, embedded in a page.
 
+``mime-type-filters`` (list)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``mime-type-filters`` is a list of dictionaries, each of which has two required
+fields, ``regex`` and ``type``. Each entry in the ``mime-type-filters`` list
+defines behavior to filter WARC-writing by the MIME type specified in the HTTP
+response's Content-Type header.
+
+There are two expected keys in a MIME type filter block:
+
+* ``regex``: A regex expression to be applied to the Content-Type header value.
+* ``type``: The type of filtering logic to apply. Two values are supported.
+  * ``REJECT``: Any Content-Type header value matching the regex will be
+    rejected.
+  * ``LIMIT``: Only Content-Type values matching the regex will be allowed.
+
 ``stats`` (dictionary)
 ~~~~~~~~~~~~~~~~~~~~~~
 ``stats`` is a dictionary with only one field understood by warcprox,
@@ -307,4 +322,3 @@ that it sends to the client. As with the request header, the value is a json
 blob. It is only included if something in the ``warcprox-meta`` request header
 calls for it. Those cases are described above in the `Warcprox-Meta http
 request header`_ section.
-

--- a/warcprox/__init__.py
+++ b/warcprox/__init__.py
@@ -276,3 +276,4 @@ import warcprox.writerthread as writerthread
 import warcprox.stats as stats
 import warcprox.bigtable as bigtable
 import warcprox.crawl_log as crawl_log
+import warcprox.mime_type_filter as mime_type_filter

--- a/warcprox/controller.py
+++ b/warcprox/controller.py
@@ -207,6 +207,9 @@ class WarcproxController(object):
     def build_postfetch_chain(self, inq):
         self._postfetch_chain = []
 
+        self.mime_type_filter = warcprox.mime_type_filter.MimeTypeFilter(self.options)
+        self._postfetch_chain.append(self.mime_type_filter)
+
         self.dedup_db = Factory.dedup_db(self.options)
 
         if self.dedup_db:

--- a/warcprox/mime_type_filter.py
+++ b/warcprox/mime_type_filter.py
@@ -1,0 +1,111 @@
+"""
+warcprox/mime_type_filter.py - postfetch processor for filtering RecordedUrls
+by MIME type specified in Content-Type header.
+
+Copyright (C) 2024 Internet Archive
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+USA.
+"""
+
+import logging
+import re
+from enum import Enum
+from typing import Dict, List
+
+from warcproxy import RequestedUrl
+
+from warcprox import BasePostfetchProcessor
+
+
+class MimeTypeFilterTypes(Enum):
+    """
+    Filtering types for the MimeTypeFilter warcprox postfetch processor.
+
+    There are two types of filtering:
+        - REJECT: Any Content-Type header value matching the regex will be
+          rejected.
+        - LIMIT: Only Content-Type values matching the regex will be allowed.
+    """
+
+    REJECT = "REJECT"
+    LIMIT = "LIMIT"
+
+
+class MimeTypeFilter(BasePostfetchProcessor):
+    """
+    A warcprox postfetch processor that filters WARC-writing based on the MIME
+    type specified in the Content-Type header of a RecordedUrl. Uses MIME type
+    filtering configuration stored in the Warcprox-Meta header.
+
+    There are two expected keys in a MIME type filter block:
+        - regex: A regex expression to be applied to the Content-Type header
+          value.
+        - type: The type of filtering logic to apply as defined in the
+          MimeTypeFilterTypes enum.
+    """
+
+    logger = logging.getLogger(__module__ + "." + __qualname__)
+
+    def _get_process_put(self) -> None:
+        """
+        Override of method from BasePostfetchProcessor to process each
+        recorded_url as it's added to the inbound queue.
+        """
+        recorded_url = self.inq.get(block=True, timeout=0.5)
+        if self.outq and not self._should_block(recorded_url):
+            self.outq.put(recorded_url)
+
+    # recorded_url is typed against RequestedUrl because FailedUrls can also be
+    # added to the queue and both RecordedUrl and FailedUrl inherit from
+    # RequestedUrl.
+    def _should_block(self, recorded_url: RequestedUrl) -> bool:
+        """
+        Determines if the URL should be blocked from further processing based
+        on the MIME type specified in the recorded_url's content_type.
+        """
+        mime_type_filters: List[Dict] = recorded_url.warcprox_meta.get(
+            "mime-type-filters", []
+        )
+        is_filtered_results = self._is_filtered(mime_type_filters, recorded_url)
+
+        return any(is_filtered_results)
+
+    def _is_filtered(
+        self, mime_type_filters: List[Dict], recorded_url: RequestedUrl
+    ) -> List[bool]:
+        """
+        Checks each MIME type filter against the recorded_url's content_type
+        and returns the a list of results.
+        """
+        filtered_results: List[bool] = []
+
+        for filter in mime_type_filters:
+            filter_type = filter.get("type")
+            filter_regex = filter.get("regex")
+            try:
+                match = re.match(filter_regex, recorded_url.content_type)
+            except re.error:
+                self.logger.warning(
+                    "Could not compile regex %s; skipping", filter_regex
+                )
+                filtered_results.append(False)
+                continue
+            if filter_type == MimeTypeFilterTypes.REJECT.value:
+                filtered_results.append(bool(match))
+            if filter_type == MimeTypeFilterTypes.LIMIT.value:
+                filtered_results.append(not bool(match))
+
+        return filtered_results


### PR DESCRIPTION
This PR adds a new postfetch processor to filter results by the MIME type specified in the HTTP response Content-Type header and adds it as a standard postfetch processor in the postfetch chain.

Documentation on the MIME type filter has been added covering usage.

Rationale for adding this as part of the standard postfetch processing chain:
- It's a generalized filter with wide applicability.
- Placing it at the beginning of the postfetch processing chain ensures results that the implementing service is not interested in will be discarded before any other potentially expensive postfetch processing (e.g. dedup, WARC writing) is executed.
- If MIME type filters are not specified, it will simply do nothing. It defaults to an empty list of MIME type filters.