### PR TITLE
Drop py2 code and unused imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# vim: set fileencoding=utf-8:
 '''
 tests/conftest.py - command line options for warcprox tests
 

--- a/tests/single-threaded-proxy.py
+++ b/tests/single-threaded-proxy.py
@@ -20,9 +20,6 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 USA.
 """
-
-from __future__ import absolute_import
-
 import warcprox
 import logging
 import sys
@@ -32,7 +29,7 @@ import queue
 import socket
 import os
 
-class FakeQueue(object):
+class FakeQueue:
     logger = logging.getLogger("FakeQueue")
     def __init__(self, maxsize=0): pass
     def join(self): pass
@@ -58,10 +55,10 @@ def parse_args():
     arg_parser.add_argument('-b', '--address', dest='address',
         default='localhost', help='address to listen on')
     arg_parser.add_argument('-c', '--cacert', dest='cacert',
-        default='./{0}-warcprox-ca.pem'.format(socket.gethostname()),
+        default='./{}-warcprox-ca.pem'.format(socket.gethostname()),
         help='CA certificate file; if file does not exist, it will be created')
     arg_parser.add_argument('--certs-dir', dest='certs_dir',
-        default='./{0}-warcprox-ca'.format(socket.gethostname()),
+        default='./{}-warcprox-ca'.format(socket.gethostname()),
         help='where to store and load generated certificates')
     arg_parser.add_argument('--onion-tor-socks-proxy', dest='onion_tor_socks_proxy',
         default=None, help='host:port of tor socks proxy, used only to connect to .onion sites')

--- a/tests/test_certauth.py
+++ b/tests/test_certauth.py
@@ -85,5 +85,5 @@ def test_create_root_subdir():
             cert.get_notAfter().decode('ascii'), '%Y%m%d%H%M%SZ')
 
     time.mktime(expected_not_before.utctimetuple())
-    assert abs((time.mktime(actual_not_before.utctimetuple()) - time.mktime(expected_not_before.utctimetuple()))) < 10
-    assert abs((time.mktime(actual_not_after.utctimetuple()) - time.mktime(expected_not_after.utctimetuple()))) < 10
+    assert abs(time.mktime(actual_not_before.utctimetuple()) - time.mktime(expected_not_before.utctimetuple())) < 10
+    assert abs(time.mktime(actual_not_after.utctimetuple()) - time.mktime(expected_not_after.utctimetuple())) < 10

--- a/tests/test_ensure_rethinkdb_tables.py
+++ b/tests/test_ensure_rethinkdb_tables.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# vim: set fileencoding=utf-8:
 '''
 tests/test_ensure_rethinkdb_tables.py - automated tests of
 ensure-rethinkdb-tables utility

--- a/tests/test_warcprox.py
+++ b/tests/test_warcprox.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# vim: set fileencoding=utf-8:
 '''
 tests/test_warcprox.py - automated tests for warcprox
 
@@ -999,7 +998,7 @@ def test_dedup_bucket_concurrency(https_daemon, http_daemon, warcprox_, archivin
     # fire off 20 initial requests simultaneously-ish
     with futures.ThreadPoolExecutor(max_workers=20) as pool:
         for i in range(20):
-            url = 'http://localhost:%s/test_dedup_bucket_concurrency/%s' % (
+            url = 'http://localhost:{}/test_dedup_bucket_concurrency/{}'.format(
                     http_daemon.server_port, i)
             headers = {"Warcprox-Meta": json.dumps({
                 "warc-prefix":"test_dedup_buckets",
@@ -1015,7 +1014,7 @@ def test_dedup_bucket_concurrency(https_daemon, http_daemon, warcprox_, archivin
     # none should be deduped
     with futures.ThreadPoolExecutor(max_workers=20) as pool:
         for i in range(20):
-            url = 'http://localhost:%s/test_dedup_bucket_concurrency/%s' % (
+            url = 'http://localhost:{}/test_dedup_bucket_concurrency/{}'.format(
                     http_daemon.server_port, -i - 1)
             headers = {"Warcprox-Meta": json.dumps({
                 "warc-prefix":"test_dedup_buckets",
@@ -1030,7 +1029,7 @@ def test_dedup_bucket_concurrency(https_daemon, http_daemon, warcprox_, archivin
     # fire off 20 requests same as the initial requests, all should be deduped
     with futures.ThreadPoolExecutor(max_workers=20) as pool:
         for i in range(20):
-            url = 'http://localhost:%s/test_dedup_bucket_concurrency/%s' % (
+            url = 'http://localhost:{}/test_dedup_bucket_concurrency/{}'.format(
                     http_daemon.server_port, i)
             headers = {"Warcprox-Meta": json.dumps({
                 "warc-prefix":"test_dedup_buckets",
@@ -1663,7 +1662,7 @@ def test_svcreg_status(warcprox_):
                 'rates_15min', 'active_requests','start_time','urls_processed',
                 'warc_bytes_written', 'postfetch_chain',
                 'earliest_still_active_fetch_start',}
-        assert status['id'] == 'warcprox:%s:%s' % (
+        assert status['id'] == 'warcprox:{}:{}'.format(
                 socket.gethostname(), warcprox_.proxy.server_port)
         assert status['role'] == 'warcprox'
         assert status['version'] == warcprox.__version__
@@ -1709,7 +1708,7 @@ def test_load_plugin():
         'warcprox.stats.RunningStats',
         'warcprox.BaseStandardPostfetchProcessor',
         'warcprox.BaseBatchPostfetchProcessor',
-        '%s.%s' % (__name__, EarlyPlugin.__name__),])
+        '{}.{}'.format(__name__, EarlyPlugin.__name__),])
     controller = warcprox.controller.WarcproxController(options)
     assert isinstance(
             controller._postfetch_chain[-1],
@@ -1815,7 +1814,7 @@ def test_crawl_log(warcprox_, http_daemon, archiving_proxies):
     port = warcprox_.proxy.server_port
     default_crawl_log_path = os.path.join(
             warcprox_.options.crawl_log_dir,
-            'crawl-%s-%s.log' % (hostname, port))
+            'crawl-{}-{}.log'.format(hostname, port))
 
     try:
         os.unlink(default_crawl_log_path)
@@ -1841,7 +1840,7 @@ def test_crawl_log(warcprox_, http_daemon, archiving_proxies):
 
     file = os.path.join(
             warcprox_.options.crawl_log_dir,
-            'test_crawl_log_1-%s-%s.log' % (hostname, port))
+            'test_crawl_log_1-{}-{}.log'.format(hostname, port))
     assert os.path.exists(file)
     assert os.stat(file).st_size > 0
     assert os.path.exists(default_crawl_log_path)
@@ -1900,7 +1899,7 @@ def test_crawl_log(warcprox_, http_daemon, archiving_proxies):
 
     file = os.path.join(
             warcprox_.options.crawl_log_dir,
-            'test_crawl_log_2-%s-%s.log' % (hostname, port))
+            'test_crawl_log_2-{}-{}.log'.format(hostname, port))
     assert os.path.exists(file)
     assert os.stat(file).st_size > 0
 
@@ -1935,7 +1934,7 @@ def test_crawl_log(warcprox_, http_daemon, archiving_proxies):
 
     file = os.path.join(
             warcprox_.options.crawl_log_dir,
-            'test_crawl_log_3-%s-%s.log' % (hostname, port))
+            'test_crawl_log_3-{}-{}.log'.format(hostname, port))
 
     assert os.path.exists(file)
     crawl_log_3 = open(file, 'rb').read()
@@ -1975,7 +1974,7 @@ def test_crawl_log(warcprox_, http_daemon, archiving_proxies):
 
     file = os.path.join(
             warcprox_.options.crawl_log_dir,
-            'test_crawl_log_4-%s-%s.log' % (hostname, port))
+            'test_crawl_log_4-{}-{}.log'.format(hostname, port))
     assert os.path.exists(file)
     crawl_log_4 = open(file, 'rb').read()
 
@@ -2009,7 +2008,7 @@ def test_crawl_log(warcprox_, http_daemon, archiving_proxies):
 
     file = os.path.join(
             warcprox_.options.crawl_log_dir,
-            'test_crawl_log_5-%s-%s.log' % (hostname, port))
+            'test_crawl_log_5-{}-{}.log'.format(hostname, port))
 
     assert os.path.exists(file)
     crawl_log_5 = open(file, 'rb').read()
@@ -2048,7 +2047,7 @@ def test_crawl_log(warcprox_, http_daemon, archiving_proxies):
 
     file = os.path.join(
             warcprox_.options.crawl_log_dir,
-            'test_crawl_log_6-%s-%s.log' % (hostname, port))
+            'test_crawl_log_6-{}-{}.log'.format(hostname, port))
 
     assert os.path.exists(file)
     crawl_log_6 = open(file, 'rb').read()
@@ -2086,7 +2085,7 @@ def test_crawl_log(warcprox_, http_daemon, archiving_proxies):
 
     file = os.path.join(
         warcprox_.options.crawl_log_dir,
-        'test_crawl_log_7-%s-%s.log' % (hostname, port))
+        'test_crawl_log_7-{}-{}.log'.format(hostname, port))
 
     assert os.path.exists(file)
     crawl_log_7 = open(file, 'rb').read()
@@ -2121,7 +2120,7 @@ def test_crawl_log(warcprox_, http_daemon, archiving_proxies):
 
     file = os.path.join(
         warcprox_.options.crawl_log_dir,
-        'test_crawl_log_8-%s-%s.log' % (hostname, port))
+        'test_crawl_log_8-{}-{}.log'.format(hostname, port))
 
     assert os.path.exists(file)
     crawl_log_8 = open(file, 'rb').read()
@@ -2137,13 +2136,13 @@ def test_crawl_log(warcprox_, http_daemon, archiving_proxies):
     assert fields[7] == b'-'
     assert re.match(br'^\d{17}[+]\d{3}', fields[8])
     assert fields[9] == b'sha1:cdd841ea7c5e46fde3fba56b2e45e4df5aeec439'
-    assert fields[10].endswith('/¶-non-ascii'.encode('utf-8'))
+    assert fields[10].endswith('/¶-non-ascii'.encode())
     assert fields[11] == b'-'
     extra_info = json.loads(fields[12].decode('utf-8'))
 
 def test_crawl_log_canonicalization():
     assert crawl_log.canonicalize_url(None) is None
-    assert crawl_log.canonicalize_url("") is ''
+    assert crawl_log.canonicalize_url("") == ''
     assert crawl_log.canonicalize_url("-") == '-'
     assert crawl_log.canonicalize_url("http://чунджа.kz/b/¶-non-ascii") == "http://xn--80ahg0a3ax.kz/b/%C2%B6-non-ascii"
     assert crawl_log.canonicalize_url("Not a URL") == "Not a URL"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -52,7 +52,7 @@ def lock_file(q, filename):
         fcntl.lockf(fi, fcntl.LOCK_EX | fcntl.LOCK_NB)
         fi.close()
         q.put('OBTAINED LOCK')
-    except IOError:
+    except OSError:
         q.put('FAILED TO OBTAIN LOCK')
 
 def test_warc_writer_locking(tmpdir):

--- a/warcprox/__init__.py
+++ b/warcprox/__init__.py
@@ -27,10 +27,7 @@ import logging
 from argparse import Namespace as _Namespace
 from pkg_resources import get_distribution as _get_distribution
 import concurrent.futures
-try:
-    import queue
-except ImportError:
-    import Queue as queue
+import queue
 import json
 
 __version__ = _get_distribution('warcprox').version
@@ -44,7 +41,7 @@ def digest_str(hash_obj, base32=False):
 class Options(_Namespace):
     def __getattr__(self, name):
         try:
-            return super(Options, self).__getattr__(self, name)
+            return super().__getattr__(self, name)
         except AttributeError:
             return None
 
@@ -76,7 +73,7 @@ class RequestBlockedByRule(Exception):
     def __init__(self, msg):
         self.msg = msg
     def __str__(self):
-        return "%s: %s" % (self.__class__.__name__, self.msg)
+        return "{}: {}".format(self.__class__.__name__, self.msg)
 
 class BadRequest(Exception):
     '''
@@ -85,7 +82,7 @@ class BadRequest(Exception):
     def __init__(self, msg):
         self.msg = msg
     def __str__(self):
-        return "%s: %s" % (self.__class__.__name__, self.msg)
+        return "{}: {}".format(self.__class__.__name__, self.msg)
 
 class BasePostfetchProcessor(threading.Thread):
     logger = logging.getLogger("warcprox.BasePostfetchProcessor")
@@ -129,7 +126,7 @@ class BasePostfetchProcessor(threading.Thread):
         raise Exception('not implemented')
 
     def _run(self):
-        threading.current_thread().name = '%s(tid=%s)' % (
+        threading.current_thread().name = '{}(tid={})'.format(
                 threading.current_thread().name, gettid())
         self.logger.info('%s starting up', self)
         self._startup()

--- a/warcprox/bigtable.py
+++ b/warcprox/bigtable.py
@@ -21,9 +21,6 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
 USA.
 """
-
-from __future__ import absolute_import
-
 import logging
 import warcprox
 import base64

--- a/warcprox/certauth.py
+++ b/warcprox/certauth.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import random
 from argparse import ArgumentParser
@@ -25,7 +24,7 @@ DEF_HASH_FUNC = hashes.SHA256()
 
 
 # =================================================================
-class CertificateAuthority(object):
+class CertificateAuthority:
     """
     Utility class for signing individual certificate
     with a root cert.

--- a/warcprox/controller.py
+++ b/warcprox/controller.py
@@ -21,9 +21,6 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
 USA.
 '''
-
-from __future__ import absolute_import
-
 import logging
 import threading
 import time
@@ -31,7 +28,6 @@ import sys
 import gc
 import datetime
 import warcprox
-import functools
 import doublethink
 import importlib
 import queue
@@ -123,7 +119,7 @@ class Factory:
         else:
             return None
 
-class WarcproxController(object):
+class WarcproxController:
     logger = logging.getLogger("warcprox.controller.WarcproxController")
 
     HEARTBEAT_INTERVAL = 20.0
@@ -320,7 +316,7 @@ class WarcproxController(object):
             status_info = self.status_info
         else:
             status_info = {
-                'id': 'warcprox:%s:%s' % (
+                'id': 'warcprox:{}:{}'.format(
                     socket.gethostname(), self.proxy.server_port),
                 'role': 'warcprox',
                 'version': warcprox.__version__,

--- a/warcprox/crawl_log.py
+++ b/warcprox/crawl_log.py
@@ -28,7 +28,7 @@ import socket
 import rfc3986
 from urllib3.exceptions import TimeoutError, HTTPError, NewConnectionError, MaxRetryError
 
-class CrawlLogger(object):
+class CrawlLogger:
     def __init__(self, dir_, options=warcprox.Options()):
         self.dir = dir_
         self.options = options
@@ -115,7 +115,7 @@ class CrawlLogger(object):
                 pass
         line = b' '.join(fields) + b'\n'
         prefix = recorded_url.warcprox_meta.get('warc-prefix', 'crawl')
-        filename = '%s-%s-%s.log' % (
+        filename = '{}-{}-{}.log'.format(
                 prefix, self.hostname, self.options.server_port)
         crawl_log_path = os.path.join(self.dir, filename)
 

--- a/warcprox/dedup.py
+++ b/warcprox/dedup.py
@@ -18,9 +18,6 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 USA.
 '''
-
-from __future__ import absolute_import
-
 import logging
 import os
 import json
@@ -37,7 +34,7 @@ from functools import lru_cache
 
 urllib3.disable_warnings()
 
-class DedupableMixin(object):
+class DedupableMixin:
     def __init__(self, options=warcprox.Options()):
         self.min_text_size = options.dedup_min_text_size or 0
         self.min_binary_size = options.dedup_min_binary_size or 0

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# vim: set fileencoding=utf-8:
 '''
 warcprox/main.py - entrypoint for warcprox executable, parses command line
 arguments, initializes components, starts controller, handles signals
@@ -21,14 +20,6 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 USA.
 '''
-
-from __future__ import absolute_import
-
-try:
-    import queue
-except ImportError:
-    import Queue as queue
-
 import logging
 import logging.config
 import sys
@@ -83,10 +74,10 @@ def _build_arg_parser(prog='warcprox', show_hidden=False):
     arg_parser.add_argument('-b', '--address', dest='address',
             default='localhost', help='address to listen on')
     arg_parser.add_argument('-c', '--cacert', dest='cacert',
-            default='./{0}-warcprox-ca.pem'.format(socket.gethostname()),
+            default='./{}-warcprox-ca.pem'.format(socket.gethostname()),
             help='CA certificate file; if file does not exist, it will be created')
     arg_parser.add_argument('--certs-dir', dest='certs_dir',
-            default='./{0}-warcprox-ca'.format(socket.gethostname()),
+            default='./{}-warcprox-ca'.format(socket.gethostname()),
             help='where to store and load generated certificates')
     arg_parser.add_argument('-d', '--dir', dest='directory',
             default='./warcs', help='where to write warcs')
@@ -319,7 +310,7 @@ def main(argv=None):
                 '%(name)s.%(funcName)s(%(filename)s:%(lineno)d) %(message)s'))
 
     if args.logging_conf_file:
-        with open(args.logging_conf_file, 'r') as fd:
+        with open(args.logging_conf_file) as fd:
             conf = yaml.safe_load(fd)
             logging.config.dictConfig(conf)
 

--- a/warcprox/playback.py
+++ b/warcprox/playback.py
@@ -19,19 +19,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 USA.
 '''
-
-from __future__ import absolute_import
-
-try:
-    import http.server as http_server
-except ImportError:
-    import BaseHTTPServer as http_server
-
-try:
-    import socketserver
-except ImportError:
-    import SocketServer as socketserver
-
+import http.server as http_server
+import socketserver
 import logging
 import os
 from hanzo import warctools
@@ -132,7 +121,7 @@ class PlaybackProxyHandler(MitmProxyHandler):
                 pass
 
             if not record:
-                raise Exception('failed to read record at offset %s from %s' % (offset, warcfilename))
+                raise Exception('failed to read record at offset {} from {}'.format(offset, warcfilename))
 
             if errors:
                 raise Exception('warc errors at {}:{} -- {}'.format(location['f'], offset, errors))
@@ -159,7 +148,7 @@ class PlaybackProxyHandler(MitmProxyHandler):
                 pass
 
             if not record:
-                raise Exception('failed to read record at offset %s from %s' % (offset, warcfilename))
+                raise Exception('failed to read record at offset {} from {}'.format(offset, warcfilename))
 
             if errors:
                 raise Exception('warc errors at {}:{} -- {}'.format(warcfilename, offset, errors))
@@ -225,14 +214,14 @@ class PlaybackProxy(socketserver.ThreadingMixIn, http_server.HTTPServer):
 
     def server_activate(self):
         http_server.HTTPServer.server_activate(self)
-        self.logger.info('PlaybackProxy listening on {0}:{1}'.format(self.server_address[0], self.server_address[1]))
+        self.logger.info('PlaybackProxy listening on {}:{}'.format(self.server_address[0], self.server_address[1]))
 
     def server_close(self):
         self.logger.info('PlaybackProxy shutting down')
         http_server.HTTPServer.server_close(self)
 
 
-class PlaybackIndexDb(object):
+class PlaybackIndexDb:
     logger = logging.getLogger("warcprox.playback.PlaybackIndexDb")
 
     def __init__(self, file='./warcprox.sqlite', options=warcprox.Options()):

--- a/warcprox/stats.py
+++ b/warcprox/stats.py
@@ -18,13 +18,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 USA.
 '''
-
-from __future__ import absolute_import
-
 from hanzo import warctools
 import collections
-import copy
-import datetime
 import doublethink
 import json
 import logging
@@ -92,7 +87,7 @@ def unravel_buckets(url, warcprox_meta):
                         domain = urlcanon.normalize_host(domain).decode('ascii')
                         if urlcanon.url_matches_domain(canon_url, domain):
                             buckets.append(
-                                    '%s:%s' % (bucket['bucket'], domain))
+                                    '{}:{}'.format(bucket['bucket'], domain))
             else:
                 buckets.append(bucket)
     else:
@@ -243,7 +238,7 @@ class RethinkStatsProcessor(StatsProcessor):
             if (not result['inserted'] and not result['replaced']
                     or sorted(result.values()) != [0,0,0,0,0,1]):
                 self.logger.error(
-                        'unexpected result %s updating stats %s' % (
+                        'unexpected result {} updating stats {}'.format(
                             result, batch_buckets[bucket]))
 
     def _bucket_batch_update_reql(self, bucket, new):

--- a/warcprox/warcproxy.py
+++ b/warcprox/warcproxy.py
@@ -19,27 +19,13 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 USA.
 '''
-
-from __future__ import absolute_import
-
-try:
-    import http.server as http_server
-except ImportError:
-    import BaseHTTPServer as http_server
-try:
-    import socketserver
-except ImportError:
-    import SocketServer as socketserver
-try:
-    import queue
-except ImportError:
-    import Queue as queue
+import http.server as http_server
+import queue
 import logging
 import json
 import socket
 from hanzo import warctools
 import warcprox
-import datetime
 import urlcanon
 import os
 import tempfile
@@ -106,15 +92,15 @@ class WarcProxyHandler(warcprox.mitmproxy.MitmProxyHandler):
         if ":" in bucket0:
             b, raw_domain = bucket0.split(":", 1)
             domain = urlcanon.normalize_host(raw_domain).decode("ascii")
-            bucket0 = "%s:%s" % (b, domain)
-            limit_key = "%s/%s/%s" % (bucket0, bucket1, bucket2)
+            bucket0 = "{}:{}".format(b, domain)
+            limit_key = "{}/{}/{}".format(bucket0, bucket1, bucket2)
 
         if not bucket0 in buckets:
             return
 
         value = self.server.stats_db.value(bucket0, bucket1, bucket2)
         if value and limit_value and limit_value > 0 and value >= limit_value:
-            body = ("request rejected by warcprox: reached %s %s=%s\n" % (
+            body = ("request rejected by warcprox: reached {} {}={}\n".format(
                         "soft limit" if soft else "limit", limit_key,
                         limit_value)).encode("utf-8")
             if soft:
@@ -138,7 +124,7 @@ class WarcProxyHandler(warcprox.mitmproxy.MitmProxyHandler):
                 self.wfile.write(body)
             self.connection.close()
             raise warcprox.RequestBlockedByRule(
-                    "%s %s %s %s -- reached %s %s=%s" % (
+                    "{} {} {} {} -- reached {} {}={}".format(
                         self.client_address[0], 430 if soft else 420,
                         self.command, self.url,
                         "soft limit" if soft else "limit",

--- a/warcprox/writer.py
+++ b/warcprox/writer.py
@@ -18,9 +18,6 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 USA.
 '''
-
-from __future__ import absolute_import
-
 import logging
 from hanzo import warctools
 import fcntl
@@ -110,7 +107,7 @@ class WarcWriter:
         if self.open_suffix == '':
             try:
                 fcntl.lockf(self.f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except IOError as exc:
+            except OSError as exc:
                 self.logger.error(
                         'could not lock file %s (%s)', self.path, exc)
         return self.f

--- a/warcprox/writerthread.py
+++ b/warcprox/writerthread.py
@@ -19,24 +19,10 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 USA.
 """
-
-from __future__ import absolute_import
-
-try:
-    import queue
-except ImportError:
-    import Queue as queue
-
 import logging
-import time
-import warcprox
-from concurrent import futures
 from datetime import datetime
-import threading
-try:
-    import queue
-except ImportError:
-    import Queue as queue
+import queue
+import warcprox
 
 class WarcWriterProcessor(warcprox.BaseStandardPostfetchProcessor):
     logger = logging.getLogger("warcprox.writerthread.WarcWriterProcessor")
@@ -46,7 +32,7 @@ class WarcWriterProcessor(warcprox.BaseStandardPostfetchProcessor):
     def __init__(self, options=warcprox.Options()):
         warcprox.BaseStandardPostfetchProcessor.__init__(self, options=options)
         self.writer_pool = warcprox.writer.WarcWriterPool(options)
-        self.method_filter = set(method.upper() for method in self.options.method_filter or [])
+        self.method_filter = {method.upper() for method in self.options.method_filter or []}
         self.blackout_period = options.blackout_period or 0
         self.close_prefix_reqs = queue.Queue()
 


### PR DESCRIPTION
Used the tool `pyupgrade --py3-only` to help identify py2 code.

Used the tool `pylint` to identify unused imports.