### PR TITLE
dependencies: add missing deps, 3.12 compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setuptools.setup(
         # preferred trough 'trough @ git+https://github.com/internetarchive/trough.git@jammy_focal'
         extras_require={'trough': 'trough'},
         setup_requires=['pytest-runner'],
-        tests_require=['mock', 'pytest', 'warcio'],
+        tests_require=['mock', 'pytest', 'warcio', 'pyOpenSSL'],
         entry_points={
             'console_scripts': [
                 'warcprox=warcprox.main:main',

--- a/warcprox/__init__.py
+++ b/warcprox/__init__.py
@@ -25,12 +25,12 @@ import threading
 import time
 import logging
 from argparse import Namespace as _Namespace
-from pkg_resources import get_distribution as _get_distribution
+from importlib.metadata import version as _version
 import concurrent.futures
 import queue
 import json
 
-__version__ = _get_distribution('warcprox').version
+__version__ = _version('warcprox')
 
 def digest_str(hash_obj, base32=False):
     import base64


### PR DESCRIPTION
pyOpenSSL is used in the tests/benchmarks, and using importlib fixes Python 3.12, which doesn't have setuptools by default.

importlib.metadata was introduced in Python 3.8; do we still support older versions? I can make this cross-compatible if necessary.