### PR TITLE
deps(benchmarks): update aiohttp

### DIFF
--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,1 +1,1 @@
-aiohttp==2.0.7
+aiohttp==3.12.9

--- a/benchmarks/run-benchmarks.py
+++ b/benchmarks/run-benchmarks.py
@@ -57,10 +57,10 @@ async def do_get(request):
             bs = rando + b'x' * 49 + b'\n'
         else:
             bs = b'x' * 79 + b'\n'
-        response.write(bs)
+        await response.write(bs)
         await response.drain()
     if n % 80 > 0:
-        response.write(b'x' * (n % 80 - 1) + b'\n')
+        await response.write(b'x' * (n % 80 - 1) + b'\n')
         await response.drain()
 
     return response

--- a/benchmarks/run-benchmarks.py
+++ b/benchmarks/run-benchmarks.py
@@ -39,6 +39,8 @@ import warcprox
 import warcprox.main
 import threading
 
+warcprox.warcproxy.WarcProxyHandler.allow_localhost = True
+
 # https://medium.com/@generativist/a-simple-streaming-http-server-in-aiohttp-4233dbc173c7
 async def do_get(request):
     n = int(request.match_info.get('n'))

--- a/benchmarks/run-benchmarks.py
+++ b/benchmarks/run-benchmarks.py
@@ -58,10 +58,8 @@ async def do_get(request):
         else:
             bs = b'x' * 79 + b'\n'
         await response.write(bs)
-        await response.drain()
     if n % 80 > 0:
         await response.write(b'x' * (n % 80 - 1) + b'\n')
-        await response.drain()
 
     return response
 
@@ -126,7 +124,7 @@ async def fetch(session, url, proxy=None):
 async def benchmarking_client(
         base_url, requests=200, payload_size=100000, proxy=None):
     start = time.time()
-    connector = aiohttp.TCPConnector(verify_ssl=False)
+    connector = aiohttp.TCPConnector(ssl=False)
     n_urls = 0
     n_bytes = 0
     url = '%s/%s' % (base_url, payload_size)


### PR DESCRIPTION
This is used only by the benchmarks and not by the app code itself. Updating to a newer version is required to make it possible for the benchmarks to run on a newer Python, since aiohttp 2.x isn't compatible with Python 3.8+.