### PR TITLE
ci: fix inputs definition

### DIFF
--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -1,11 +1,9 @@
 name: Test setup
 
-on:
-  workflow-call:
-    inputs:
-      python-version:
-        required: true
-        type: string
+inputs:
+  python-version:
+    required: true
+    type: string
 
 runs:
   using: composite


### PR DESCRIPTION
Looks like I followed the wrong pattern here: https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action#creating-an-action-metadata-file