### PR TITLE
Remove obsolete cryptography workaround

### DIFF
--- a/benchmarks/run-benchmarks.py
+++ b/benchmarks/run-benchmarks.py
@@ -184,9 +184,6 @@ Benchmarking code uses asyncio/aiohttp and requires python 3.5 or later.
     return arg_parser
 
 if __name__ == '__main__':
-    # see https://github.com/pyca/cryptography/issues/2911
-    cryptography.hazmat.backends.openssl.backend.activate_builtin_random()
-
     # with tempfile.TemporaryDirectory() as tmpdir:
     tmpdir = tempfile.mkdtemp()
     if True:

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -317,9 +317,6 @@ def main(argv=None):
             conf = yaml.safe_load(fd)
             logging.config.dictConfig(conf)
 
-    # see https://github.com/pyca/cryptography/issues/2911
-    cryptography.hazmat.backends.openssl.backend.activate_builtin_random()
-
     options = warcprox.Options(**vars(args))
     controller = warcprox.controller.WarcproxController(options)
 


### PR DESCRIPTION
As far as I can tell, this isn't needed anymore. A comment from one of the reporters on the cryptography repo indicates it hasn't been reproducible for awhile: https://github.com/pyca/cryptography/issues/4837

The entire function we're calling no longer exists as of cryptography 41.0.0 and later.

Fixes #196.