### PR TITLE
ci: test on 3.14 prereleases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['3.8', '3.12']
+        version: ['3.8', '3.12', '3.14']
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Like [with brozzler](https://github.com/internetarchive/brozzler/pull/383), I think this late point in the Python 3.14 beta cycle is a good time for us to be testing with 3.14 to make sure we're compatible.