### PR TITLE
fix: skip mime_type_filter for None Content-Type

### DIFF
--- a/warcprox/mime_type_filter.py
+++ b/warcprox/mime_type_filter.py
@@ -97,6 +97,13 @@ class MimeTypeFilter(BasePostfetchProcessor):
         for filter in mime_type_filters:
             filter_type = filter.get("type")
             filter_regex = filter.get("regex")
+
+            if recorded_url.content_type is None:
+                self.logger.warning(
+                    "content_type not known for %s; skipping match", recorded_url.url
+                )
+                continue
+
             try:
                 match = re.match(filter_regex, recorded_url.content_type)
             except re.error:


### PR DESCRIPTION
We can sometimes get a RecordedUrl with a `None` `Content-Type` field; we can't match these, so dont' even try.