### PR TITLE
release: 2.8.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ except:
 
 setuptools.setup(
         name='warcprox',
-        version='2.8.0',
+        version='2.8.1',
         description='WARC writing MITM HTTP/S proxy',
         url='https://github.com/internetarchive/warcprox',
         author='Noah Levitt',

--- a/warcprox/mime_type_filter.py
+++ b/warcprox/mime_type_filter.py
@@ -90,7 +90,7 @@ class MimeTypeFilter(BasePostfetchProcessor):
     ) -> List[bool]:
         """
         Checks each MIME type filter against the recorded_url's content_type
-        and returns the a list of results.
+        and returns the list of results.
         """
         filtered_results: List[bool] = []
 

--- a/warcprox/mime_type_filter.py
+++ b/warcprox/mime_type_filter.py
@@ -94,15 +94,15 @@ class MimeTypeFilter(BasePostfetchProcessor):
         """
         filtered_results: List[bool] = []
 
+        if recorded_url.content_type is None:
+            self.logger.warning(
+                "content_type not known for %s; skipping match", recorded_url.url
+            )
+            return []
+
         for filter in mime_type_filters:
             filter_type = filter.get("type")
             filter_regex = filter.get("regex")
-
-            if recorded_url.content_type is None:
-                self.logger.warning(
-                    "content_type not known for %s; skipping match", recorded_url.url
-                )
-                continue
 
             try:
                 match = re.match(filter_regex, recorded_url.content_type)


### PR DESCRIPTION
This release contains a minor bug fix for the MIME type filter added in [2.8.0](https://github.com/internetarchive/warcprox/releases/tag/2.8.0).

* fix: skip mime_type_filter for None Content-Type (#232/#233) 