### PR TITLE
release: 2.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ except:
 
 setuptools.setup(
         name='warcprox',
-        version='2.8.1',
+        version='2.9.0',
         description='WARC writing MITM HTTP/S proxy',
         url='https://github.com/internetarchive/warcprox',
         author='Noah Levitt',


### PR DESCRIPTION
This release contains no new features but makes adjustments to warcprox's logging. Several `INFO`-level log statements have been moved down to `DEBUG`; we don't expect that most users will need these statements in normal production use, but they're still available when running warcprox with the `--verbose` option.

* crawl_log: reduce level of three info logs (#234)
* writer_thread: reduce log to debug (#235)