### PR TITLE
mime_type filter: fix matching null content-types

### DIFF
--- a/tests/test_warcprox.py
+++ b/tests/test_warcprox.py
@@ -2032,7 +2032,7 @@ def test_crawl_log(warcprox_, http_daemon, archiving_proxies):
     assert fields[3].endswith(b'/space_in_content_type')
     assert fields[4] == b'-'
     assert fields[5] == b'-'
-    assert fields[6] == b'-'
+    assert fields[6] == b'unknown'
     assert fields[7] == b'-'
     assert re.match(br'^\d{17}[+]\d{3}', fields[8])
     assert fields[9] == b'sha1:a94a8fe5ccb19ba61c4c0873d391e987982fbbd3'
@@ -2073,7 +2073,7 @@ def test_crawl_log(warcprox_, http_daemon, archiving_proxies):
     assert fields[3].endswith(b'/connection-error')
     assert fields[4] == b'-'
     assert fields[5] == b'-'
-    assert fields[6] == b'-'
+    assert fields[6] == b'unknown'
     assert fields[7] == b'-'
     assert fields[8] == b'-'
     assert fields[9] == b'-'
@@ -2109,7 +2109,7 @@ def test_crawl_log(warcprox_, http_daemon, archiving_proxies):
     assert fields[3].endswith(b'/connection-error')
     assert fields[4] == b'-'
     assert fields[5] == b'-'
-    assert fields[6] == b'-'
+    assert fields[6] == b'unknown'
     assert fields[7] == b'-'
     assert fields[8] == b'-'
     assert fields[9] == b'-'

--- a/warcprox/crawl_log.py
+++ b/warcprox/crawl_log.py
@@ -96,7 +96,7 @@ class CrawlLogger:
             recorded_url.url,
             hop_path,
             via_url,
-            recorded_url.mimetype if recorded_url.mimetype is not None and recorded_url.mimetype.strip() else '-',
+            recorded_url.mimetype if recorded_url.mimetype is not None and recorded_url.mimetype.strip() else 'unknown',
             '-',
             '{:%Y%m%d%H%M%S}{:03d}+{:03d}'.format(
                 recorded_url.timestamp,

--- a/warcprox/mime_type_filter.py
+++ b/warcprox/mime_type_filter.py
@@ -94,15 +94,16 @@ class MimeTypeFilter(BasePostfetchProcessor):
         """
         filtered_results: List[bool] = []
 
-        if recorded_url.content_type is None:
-            self.logger.warning(
-                "content_type not known for %s; skipping match", recorded_url.url
-            )
-            return []
-
         for filter in mime_type_filters:
             filter_type = filter.get("type")
             filter_regex = filter.get("regex")
+
+            if recorded_url.content_type is None:
+                # A null content type will by definition never match
+                # the LIMIT regex, so always return True
+                if filter_type == MimeTypeFilterTypes.LIMIT.value:
+                    filtered_results.append(True)
+                continue
 
             try:
                 match = re.match(filter_regex, recorded_url.content_type)


### PR DESCRIPTION
This was accidentally broken in 2.8.1 (dd0edc120b100e8868bdd530acda385da244f06b), which skipped the entire chain if the content-type was null. That's incorrect; it meant we'd allow these records to continue processing, whereas we actually do want to skip them for LIMIT-type filters.