### PR TITLE
release: 2.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "warcprox"
-version = "2.9.0"
+version = "2.10.0"
 authors = [
   { name="Noah Levitt", email="nlevitt@archive.org" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1098,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "warcprox"
-version = "2.9.0"
+version = "2.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
This release contains a bugfix for the MIME type filter and a minor breaking change to the crawl log format.

This release drops support for Python 3.8. The minimum version is now 3.9.

* The crawl log format previously represented a null content type by writing the single character `-`, like with other null types. This is inconsistent with Heritrix, which instead writes a null content type as the string `unknown`. This release has switched over to using `unknown` like Heritrix. (#237)
* The MIME type filter had a bug which meant that `LIMIT` filters wouldn't be applied to recorded URLs with a null content type. This has been fixed, ensuring those records can skip archiving as intended.