### PR TITLE
gitignore: add .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build
 dist
 .tox
 out.*
+.DS_Store
 
 # runtime files
 /warcprox.sqlite


### PR DESCRIPTION
Making sure we don't accidentally commit any stray `.DS_Store`s.