### PR TITLE
Optional Sentry Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ dist
 .tox
 out.*
 .DS_Store
+.idea
+.eggs/README.txt
 
 # runtime files
 /warcprox.sqlite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
 
 [project.optional-dependencies]
 trough = ["trough"]
+sentry = ["sentry-sdk"]
 
 [project.urls]
 Homepage = "https://github.com/internetarchive/warcprox"

--- a/uv.lock
+++ b/uv.lock
@@ -928,6 +928,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.39.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/72/43294fa4bdd75c51610b5104a3ff834459ba653abb415150aa7826a249dd/sentry_sdk-2.39.0.tar.gz", hash = "sha256:8c185854d111f47f329ab6bc35993f28f7a6b7114db64aa426b326998cfa14e9", size = 348556, upload-time = "2025-09-25T09:15:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/44/4356cc64246ba7b2b920f7c97a85c3c52748e213e250b512ee8152eb559d/sentry_sdk-2.39.0-py2.py3-none-any.whl", hash = "sha256:ba655ca5e57b41569b18e2a5552cb3375209760a5d332cdd87c6c3f28f729602", size = 370851, upload-time = "2025-09-25T09:15:36.35Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1116,6 +1129,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+sentry = [
+    { name = "sentry-sdk" },
+]
 trough = [
     { name = "trough" },
 ]
@@ -1138,13 +1154,14 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.1" },
     { name = "requests", specifier = ">=2.0.1" },
     { name = "rfc3986", specifier = ">=1.5.0" },
+    { name = "sentry-sdk", marker = "extra == 'sentry'" },
     { name = "setuptools", marker = "python_full_version >= '3.12'", specifier = ">=75.8.0" },
     { name = "trough", marker = "extra == 'trough'" },
     { name = "urlcanon", specifier = ">=0.3.0" },
     { name = "urllib3", specifier = ">=1.23" },
     { name = "warctools", specifier = ">=5.0.0" },
 ]
-provides-extras = ["trough"]
+provides-extras = ["trough", "sentry"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -258,6 +258,9 @@ def _build_arg_parser(prog='warcprox', show_hidden=False):
             '--sentry-dsn', dest='sentry_dsn', default=None,
             help='Sentry DSN for error reporting and monitoring')
     arg_parser.add_argument(
+        '--sentry-traces-sample-rate', dest='sentry_traces_sample_rate', default=1,
+        help='Sample rate for Sentry traces. Default is 1, which means 1% of transactions are sampled.')
+    arg_parser.add_argument(
             '--deploy-environment', dest='deploy_environment', default='DEV',
             help=('Is this warcprox running in PROD, QA, DEV, etc? '
                   'Used to distinguish events in Sentry.')
@@ -342,7 +345,7 @@ def main(argv=None):
         sentry_sdk.init(
             dsn=args.sentry_dsn,
             integrations=[sentry_logging],
-            traces_sample_rate=0.01,  # 1% of transactions for performance monitoring
+            traces_sample_rate=args.sentry_traces_sample_rate, # 1 is 1%, 100 is 100%
             environment=args.deploy_environment,
             release=warcprox.__version__
         )


### PR DESCRIPTION
Optionally run warcprox with Sentry support.

The `sentry-sdk` PyPI package becomes an optional dependency in group `[sentry]`.

Adds three CLI parameters to warcprox:
- `--sentry-dsn`
- `--sentry-traces-sample-rate`
- `--deploy-environment`

Most issues will be captured via Sentry's `LoggingIntegration`. Logged events with level ERROR or greater will be captured as Sentry events.