### PR TITLE
ssl: add option to enable legacy renegotiation

### DIFF
--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -198,6 +198,10 @@ def _build_arg_parser(prog='warcprox', show_hidden=False):
             '--ssl-context', dest='ssl_context', default=None, help=(
                 'emulate chrome and firefox tls fingerprints'))
     arg_parser.add_argument(
+            '--unsafe-legacy-renegotiation', dest='legacy_renegotiation',
+            default=False, action='store_true', 
+            help='enable legacy unsafe SSL renegotiation')
+    arg_parser.add_argument(
             '--onion-tor-socks-proxy', dest='onion_tor_socks_proxy',
             default=None, help=(
                 'host:port of tor socks proxy, used only to connect to '

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -798,6 +798,9 @@ class SingleThreadedMitmProxy(http_server.HTTPServer):
         ssl_context.check_hostname = False
         ssl_context.verify_mode = ssl.CERT_NONE
 
+        if options.legacy_renegotiation:
+            ssl_context.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
+
         self.remote_connection_pool = PoolManager(
             ssl_context=ssl_context,
             num_pools=max((options.max_threads or 0) // 6, 400), maxsize=6)

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -797,6 +797,7 @@ class SingleThreadedMitmProxy(http_server.HTTPServer):
             ssl_context = create_urllib3_context()
         ssl_context.check_hostname = False
         ssl_context.verify_mode = ssl.CERT_NONE
+        ssl_context.options |= 0x80  # OP_IGNORE_UNEXPECTED_EOF
 
         if options.legacy_renegotiation:
             ssl_context.options |= 0x4  # OP_LEGACY_SERVER_CONNECT


### PR DESCRIPTION
By default, the ssl library disables insecure renegotiation. However, there are still servers running the old renegotiation strategy and these can't be connected to without telling OpenSSL to accept it. I've tested with one of these servers I've come across live on the web and I've confirmed that warcprox is unable to capture from it without this option, but that web browsers (such as Safari, Chrome and Firefox) are happy to connect to it.

I've made this an option since it's a security option, and made it opt-in.

refs https://datatracker.ietf.org/doc/html/rfc5746
refs CVE-2009-3555

I've added a second SSL-related change as well - "unexpected EOF while reading" is an error in more recent versions of OpenSSL, but I encountered a real server in the wild that serves these up while we're connecting. Telling `ssl` to ignore that is necessary in order to properly capture from that server.

Both of these options have constants in newer versions of Python, but not in the oldest versions of Python still supported by warcprox, so I've settled for using the integer values.