### PR TITLE
main: remove stray comma from argparse

### DIFF
--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -82,7 +82,7 @@ def _build_arg_parser(prog='warcprox', show_hidden=False):
     arg_parser.add_argument('-d', '--dir', dest='directory',
             default='./warcs', help='where to write warcs')
     arg_parser.add_argument('--subdir-prefix', dest='subdir_prefix', action='store_true',
-                            help='write warcs to --dir subdir equal to the current warc-prefix'),
+                            help='write warcs to --dir subdir equal to the current warc-prefix')
     arg_parser.add_argument('--warc-filename', dest='warc_filename',
             default='{prefix}-{timestamp17}-{serialno}-{randomtoken}',
             help='define custom WARC filename with variables {prefix}, {timestamp14}, {timestamp17}, {serialno}, {randomtoken}, {hostname}, {shorthostname}, {port}')


### PR DESCRIPTION
Saw pyright flagging this as an "unused expression" and was trying to figure out why, until I realized there's a stray comma at the end of this line which is causing it to return an unused tuple.