### PR TITLE
warcprox: OP_IGNORE_UNEXPECTED_EOF in server too

### DIFF
--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -328,6 +328,8 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
         # Load the certificate into the context
         context.load_cert_chain(certfile)
 
+        context.options |= 0x80  # OP_IGNORE_UNEXPECTED_EOF
+
         self.request = self.connection = context.wrap_socket(
                 self.connection, server_side=True)
         # logging.info('self.hostname=%s certfile=%s', self.hostname, certfile)


### PR DESCRIPTION
Unexpected EOFs were previously ignored when sending requests in be41954460927c43d7dc102d5d05c3acbbf1bd28, but not in the context used in the HTTP server where we're receiving requests. It looks like these happen in that context too, so probably best to set the flag here as well.

cc @vbanos 