### PR TITLE
Use logging.debug when the exception occurs

### DIFF
--- a/warcprox/controller.py
+++ b/warcprox/controller.py
@@ -231,13 +231,13 @@ class WarcproxController:
             if isinstance(sock, socket.socket):
                 try:
                     result['earliest_still_active_socket']['name'] = sock.getsockname()
-                    self.logger.debug("Unable to get socket name for socket %s", sock)
                 except OSError:
+                    self.logger.debug("Unable to get socket name for socket %s", sock)
                     pass
                 try:
                     result['earliest_still_active_socket']['peername'] = sock.getpeername()
-                    self.logger.debug("Unable to get socket peername for socket %s", sock)
                 except OSError:
+                    self.logger.debug("Unable to get socket peername for socket %s", sock)
                     pass
 
         if future := active_fetch['future']:


### PR DESCRIPTION
The current code runs `logging.debug` when there is no exception.