### PR TITLE
watchdog closes sockets open for more than fetch_timeout seconds

### DIFF
--- a/demo/watchdog_demo.py
+++ b/demo/watchdog_demo.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Demo: how warcprox responds when an upstream HTTP server slow-dribbles bytes
+inside a chunked response, with and without the --fetch-timeout watchdog.
+
+Run twice to compare:
+
+    python demo/watchdog_demo.py --fetch-timeout 0     # watchdog DISABLED
+    python demo/watchdog_demo.py --fetch-timeout 10    # watchdog kills stuck
+                                                       # fetches at 10s
+
+Press Enter to fire a single request through warcprox, then watch /status
+poll output. Without the watchdog, seconds_behind grows without bound;
+the request never completes (Ctrl-C to exit). With the watchdog enabled,
+the request fails with 502 after fetch_timeout, /status clears, and
+warcprox is healthy again.
+
+Why this hangs warcprox without the watchdog: the slow-loris sends bytes
+within the per-recv socket timeout (so it never fires) but never sends a
+\\n. The handler is parked inside http.client._read_next_chunk_size's
+readline call, which can't return until it sees a newline.
+"""
+import argparse
+import http.server
+import json
+import logging
+import socketserver
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+
+import warcprox
+import warcprox.controller
+import warcprox.warcproxy
+
+# warcprox blocks proxy requests to localhost by default; allow them here.
+warcprox.warcproxy.WarcProxyHandler.allow_localhost = True
+
+
+class SlowLoris(http.server.BaseHTTPRequestHandler):
+    """Sends a single valid chunk, then dribbles bytes without newlines."""
+
+    DRIBBLE_INTERVAL = 2.0  # seconds between sends; must be < socket_timeout
+
+    def do_GET(self):
+        print(f'[upstream] got request: {self.path}', flush=True)
+        self.send_response(200)
+        self.send_header('Transfer-Encoding', 'chunked')
+        self.end_headers()
+        self.wfile.write(b'5\r\nhello\r\n')
+        self.wfile.flush()
+        print(f'[upstream] sent first chunk; now dribbling "." every '
+              f'{self.DRIBBLE_INTERVAL}s without newlines',
+              flush=True)
+        try:
+            while True:
+                self.wfile.write(b'.')
+                self.wfile.flush()
+                time.sleep(self.DRIBBLE_INTERVAL)
+        except (BrokenPipeError, ConnectionResetError, OSError) as e:
+            print(f'[upstream] client closed: {type(e).__name__}', flush=True)
+
+    def log_message(self, fmt, *args):
+        pass
+
+
+class ThreadedHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+def start_upstream():
+    server = ThreadedHTTPServer(('127.0.0.1', 0), SlowLoris)
+    threading.Thread(
+            target=server.serve_forever, daemon=True,
+            name='SlowLorisThread').start()
+    return server
+
+
+def start_warcprox(fetch_timeout):
+    options = warcprox.Options(
+        port=0,
+        address='127.0.0.1',
+        dedup_db_file='/dev/null',
+        stats_db_file='/dev/null',
+        queue_size=100,
+        max_threads=8,
+        socket_timeout=3.0,
+        fetch_timeout=fetch_timeout,
+    )
+    controller = warcprox.controller.WarcproxController(options=options)
+    controller.start()
+    return controller
+
+
+def fetch_status(proxy_port):
+    try:
+        with urllib.request.urlopen(
+                f'http://localhost:{proxy_port}/status', timeout=3) as r:
+            return json.loads(r.read())
+    except Exception as e:
+        return {'error': repr(e)}
+
+
+def fire_request(proxy_port, upstream_port):
+    """Fire a single proxied GET in a daemon thread; return the thread."""
+    url = f'http://127.0.0.1:{upstream_port}/foo'
+    proxy_handler = urllib.request.ProxyHandler({
+        'http': f'http://localhost:{proxy_port}'})
+    opener = urllib.request.build_opener(proxy_handler)
+    started = time.monotonic()
+
+    def _go():
+        try:
+            with opener.open(url, timeout=600) as r:
+                body = r.read()
+                age = time.monotonic() - started
+                print(f'[client] response complete after {age:.1f}s '
+                      f'status={r.status} bytes={len(body)}', flush=True)
+        except urllib.error.HTTPError as e:
+            age = time.monotonic() - started
+            print(f'[client] HTTP error after {age:.1f}s: '
+                  f'{e.code} {e.reason}', flush=True)
+        except Exception as e:
+            age = time.monotonic() - started
+            print(f'[client] request failed after {age:.1f}s: '
+                  f'{e!r}', flush=True)
+
+    t = threading.Thread(target=_go, daemon=True, name='ClientThread')
+    t.start()
+    return t
+
+
+def main():
+    p = argparse.ArgumentParser(
+            description=__doc__,
+            formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument('--fetch-timeout', type=float, default=0.0,
+                   help='watchdog cap (seconds); 0 disables (default 0)')
+    p.add_argument('--watch-seconds', type=float, default=60.0,
+                   help='how long to poll /status (default 60s)')
+    args = p.parse_args()
+
+    # Surface the watchdog WARNING when it fires.
+    logging.basicConfig(
+        level=logging.WARNING,
+        format='[warcprox %(name)s] %(levelname)s: %(message)s')
+
+    upstream = start_upstream()
+    upstream_port = upstream.server_address[1]
+    print(f'[upstream] slow-loris listening on 127.0.0.1:{upstream_port}',
+          flush=True)
+
+    controller = start_warcprox(args.fetch_timeout)
+    proxy_port = controller.proxy.server_port
+    if args.fetch_timeout:
+        mode = f'fetch-timeout={args.fetch_timeout}s (watchdog ENABLED)'
+    else:
+        mode = 'fetch-timeout=0 (watchdog DISABLED)'
+    print(f'[warcprox] listening on 127.0.0.1:{proxy_port} {mode}',
+          flush=True)
+
+    try:
+        input('Press Enter to fire request through warcprox... ')
+    except (EOFError, KeyboardInterrupt):
+        pass
+
+    client = fire_request(proxy_port, upstream_port)
+    fired_at = time.monotonic()
+
+    print(f'[demo] polling /status every 2s for up to '
+          f'{args.watch_seconds:.0f}s', flush=True)
+    try:
+        while time.monotonic() - fired_at < args.watch_seconds:
+            time.sleep(2.0)
+            st = fetch_status(proxy_port)
+            t = time.monotonic() - fired_at
+            ar = st.get('active_requests')
+            sb = st.get('seconds_behind')
+            earliest = st.get('earliest_still_active_fetch_start')
+            print(f'[t={t:5.1f}s] active_requests={ar!s:>3} '
+                  f'seconds_behind={sb!s:>5} '
+                  f'earliest_still_active_fetch_start={earliest}',
+                  flush=True)
+            if not client.is_alive():
+                print('[demo] client request thread finished',
+                      flush=True)
+                break
+    except KeyboardInterrupt:
+        print('\n[demo] interrupted by user', flush=True)
+    finally:
+        print('[demo] shutting down warcprox & upstream...', flush=True)
+        controller.stop.set()
+        try:
+            controller.shutdown()
+        except Exception:
+            pass
+        upstream.shutdown()
+        upstream.server_close()
+
+
+if __name__ == '__main__':
+    sys.exit(main() or 0)

--- a/tests/test_warcprox.py
+++ b/tests/test_warcprox.py
@@ -1685,6 +1685,47 @@ def test_svcreg_status(warcprox_):
         assert status['pid'] == os.getpid()
         assert status['threads'] == warcprox_.proxy.pool._max_workers
 
+def _make_watchdog_controller(fetch_timeout):
+    """Build a controller with port=0 so concurrent test runs don't clash."""
+    options = warcprox.Options(
+            port=0, address='127.0.0.1', fetch_timeout=fetch_timeout)
+    return warcprox.controller.WarcproxController(options=options)
+
+
+def test_fetch_watchdog_aborts_stuck_upstream_sockets():
+    """Watchdog calls shutdown(SHUT_RDWR) on upstream sockets older than
+    options.fetch_timeout, leaves fresh ones alone, and tolerates already-
+    closed sockets."""
+    controller = _make_watchdog_controller(fetch_timeout=10.0)
+
+    fresh = mock.Mock()       # young — should not be aborted
+    stuck = mock.Mock()       # old — should be aborted
+    closed = mock.Mock()      # old, already-closed — shutdown raises OSError
+    closed.shutdown.side_effect = OSError('already closed')
+
+    now = 1000.0
+    controller.proxy.remote_server_socks = {
+        fresh: now - 5.0,     # 5s old, under threshold
+        stuck: now - 30.0,    # 30s old, over threshold
+        closed: now - 30.0,   # also over threshold
+    }
+
+    with mock.patch('time.monotonic', return_value=now):
+        controller._abort_stuck_fetches()
+
+    fresh.shutdown.assert_not_called()
+    stuck.shutdown.assert_called_once_with(socket.SHUT_RDWR)
+    closed.shutdown.assert_called_once_with(socket.SHUT_RDWR)
+
+
+def test_fetch_watchdog_disabled_when_timeout_zero():
+    controller = _make_watchdog_controller(fetch_timeout=0)
+    sock = mock.Mock()
+    controller.proxy.remote_server_socks = {sock: 0.0}  # ancient
+    controller._abort_stuck_fetches()
+    sock.shutdown.assert_not_called()
+
+
 def test_controller_with_defaults():
     # tests some initialization code that we rarely touch otherwise
     controller = warcprox.controller.WarcproxController()

--- a/warcprox/controller.py
+++ b/warcprox/controller.py
@@ -135,6 +135,7 @@ class WarcproxController:
     logger = logging.getLogger("warcprox.controller.WarcproxController")
 
     HEARTBEAT_INTERVAL = 20.0
+    WATCHDOG_INTERVAL = 5.0
 
     def __init__(self, options=warcprox.Options()):
         """
@@ -144,6 +145,7 @@ class WarcproxController:
 
         self.proxy_thread = None
         self.playback_proxy_thread = None
+        self.watchdog_thread = None
         self._last_rss = None
         self.stop = threading.Event()
         self._start_stop_lock = threading.Lock()
@@ -433,6 +435,46 @@ class WarcproxController:
             for processor in self._postfetch_chain:
                 processor.start()
 
+            if getattr(self.options, 'fetch_timeout', 0):
+                self.watchdog_thread = threading.Thread(
+                        target=self._watchdog, name='FetchWatchdogThread')
+                self.watchdog_thread.start()
+
+    def _watchdog(self):
+        '''
+        Periodically aborts upstream sockets whose fetch has been running
+        longer than `options.fetch_timeout`. Required because the per-recv
+        socket timeout doesn't fire when a malicious or buggy upstream
+        dribbles bytes (e.g. inside a chunk-size header that never ends in
+        \\n), parking the handler thread inside a single readline indefinitely.
+        '''
+        while not self.stop.wait(self.WATCHDOG_INTERVAL):
+            try:
+                self._abort_stuck_fetches()
+            except Exception:
+                self.logger.error(
+                        'fetch watchdog raised; will retry next tick',
+                        exc_info=True)
+
+    def _abort_stuck_fetches(self):
+        timeout = getattr(self.options, 'fetch_timeout', 0)
+        if not timeout:
+            return
+        now = time.monotonic()
+        with self.proxy.remote_server_socks_lock:
+            stuck = [(s, now - t)
+                     for s, t in self.proxy.remote_server_socks.items()
+                     if now - t > timeout]
+        for sock, age in stuck:
+            try:
+                self.logger.warning(
+                        'aborting stuck upstream fetch (age=%.0fs sock=%r)',
+                        age, sock)
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError as e:
+                self.logger.debug(
+                        'shutdown of stuck upstream sock failed: %r', e)
+
     def shutdown(self):
         '''
         Shut down, aborting active connections, but allowing completed fetches
@@ -448,6 +490,10 @@ class WarcproxController:
             if not self.proxy_thread or not self.proxy_thread.is_alive():
                 self.logger.info('warcprox is not running')
                 return
+
+            # ensure the watchdog wakes from its self.stop.wait() even if
+            # shutdown() is called directly rather than via run_until_shutdown.
+            self.stop.set()
 
             self.proxy.shutdown()
             self.proxy.server_close()
@@ -465,6 +511,11 @@ class WarcproxController:
 
             if self.playback_proxy is not None:
                 self.playback_proxy_thread.join()
+
+            if self.watchdog_thread is not None:
+                # self.stop is already set by run_until_shutdown / caller;
+                # the watchdog wakes from its self.stop.wait() and exits.
+                self.watchdog_thread.join()
 
             if self.service_registry and hasattr(self, "status_info"):
                 self.service_registry.unregister(self.status_info["id"])

--- a/warcprox/main.py
+++ b/warcprox/main.py
@@ -223,6 +223,13 @@ def _build_arg_parser(prog='warcprox', show_hidden=False):
             help=suppress(
                 'socket timeout, used for proxy client connection and for '
                 'connection to remote server'))
+    arg_parser.add_argument(
+            '--fetch-timeout', dest='fetch_timeout', type=float, default=1800,
+            help=(
+                'wall-clock timeout per upstream fetch in seconds; a watchdog '
+                'aborts upstream sockets older than this. Protects against '
+                'slow-trickle upstream responses where the per-recv socket '
+                'timeout never fires. 0 to disable. Default: 1800 (30 min)'))
     # Increasing this value increases memory usage but reduces /tmp disk I/O.
     hidden.add_argument(
             '--tmp-file-max-memory-size', dest='tmp_file_max_memory_size',

--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -699,16 +699,19 @@ class PooledMixIn(socketserver.ThreadingMixIn):
 
 class MitmProxy(http_server.HTTPServer):
     def __init__(self, *args, **kwargs):
-        self.remote_server_socks = set()
+        # maps in-flight upstream socket -> monotonic time when the fetch
+        # started, used by WarcproxController's watchdog to abort fetches
+        # whose upstream is dribbling bytes (defeating per-recv timeouts).
+        self.remote_server_socks = {}
         self.remote_server_socks_lock = threading.Lock()
 
     def register_remote_server_sock(self, sock):
         with self.remote_server_socks_lock:
-            self.remote_server_socks.add(sock)
+            self.remote_server_socks[sock] = time.monotonic()
 
     def unregister_remote_server_sock(self, sock):
         with self.remote_server_socks_lock:
-            self.remote_server_socks.discard(sock)
+            self.remote_server_socks.pop(sock, None)
 
     def finish_request(self, request, client_address):
         '''


### PR DESCRIPTION
This MR introduces a new `--fetch-timeout` flag and socket watchdog. By default it will limit fetches to 30 minutes, and should help preserve warcprox performance over a long period of time.

> --fetch-timeout: wall-clock timeout per upstream fetch in seconds; a watchdog aborts upstream sockets older than this. Protects against slow-trickle upstream responses where the per-recv socket timeout never fires. 0 to disable. Default: 1800 (30 min)

We see sockets get stuck this way every day, where a single read gets a few bytes every few seconds for hours on end. These servers, intentionally or not, send data with enough frequency so the existing `socket_timeout` is not triggered. When this happens, the socket holds the `earliest_still_active_fetch_start`, and a thread.

A demo is included to show how warcprox responds with and without `--fetch-timeout`.

Disable --fetch-timeout by passing 0:
```
uv run demo/watchdog_demo.py --fetch-timeout=0
[upstream] slow-loris listening on 127.0.0.1:55605
[warcprox] listening on 127.0.0.1:55606 fetch-timeout=0 (watchdog DISABLED)
Press Enter to fire request through warcprox... 
[demo] polling /status every 2s for up to 60s
[upstream] got request: /foo
[upstream] sent first chunk; now dribbling "." every 2.0s without newlines
[t=  2.0s] active_requests=  2 seconds_behind=1.999454 earliest_still_active_fetch_start=2026-05-08T06:19:57.568156+00:00
[t=  4.0s] active_requests=  2 seconds_behind=4.006784 earliest_still_active_fetch_start=2026-05-08T06:19:57.568156+00:00
[demo] interrupted by user
[demo] shutting down warcprox & upstream...
```

Demo --fetch-timeout with a non-zero value:
```
uv run demo/watchdog_demo.py --fetch-timeout=10
[upstream] slow-loris listening on 127.0.0.1:55031
[warcprox] listening on 127.0.0.1:55032 fetch-timeout=10.0s (watchdog ENABLED)
Press Enter to fire request through warcprox... 
[demo] polling /status every 2s for up to 60s
[upstream] got request: /foo
[upstream] sent first chunk; now dribbling "." every 2.0s without newlines
[t=  2.0s] active_requests=  2 seconds_behind=2.000577 earliest_still_active_fetch_start=2026-05-08T06:11:49.678887+00:00
[t=  4.0s] active_requests=  2 seconds_behind=4.009564 earliest_still_active_fetch_start=2026-05-08T06:11:49.678887+00:00
[t=  6.0s] active_requests=  2 seconds_behind=6.018962 earliest_still_active_fetch_start=2026-05-08T06:11:49.678887+00:00
[t=  8.0s] active_requests=  2 seconds_behind=8.024868 earliest_still_active_fetch_start=2026-05-08T06:11:49.678887+00:00
[t= 10.0s] active_requests=  2 seconds_behind=10.035741 earliest_still_active_fetch_start=2026-05-08T06:11:49.678887+00:00
[t= 12.1s] active_requests=  2 seconds_behind=12.042167 earliest_still_active_fetch_start=2026-05-08T06:11:49.678887+00:00
[warcprox warcprox.controller.WarcproxController] WARNING: aborting stuck upstream fetch (age=13s sock=<socket.socket fd=9, family=2, type=1, proto=6, laddr=('127.0.0.1', 55034), raddr=('127.0.0.1', 55031)>)
[warcprox warcprox.warcprox.WarcProxyHandler] WARNING: IncompleteRead(5 bytes read) from http://127.0.0.1:55031/foo
[client] request failed after 12.7s: IncompleteRead(5 bytes read)
[t= 14.1s] active_requests=  1 seconds_behind=0.001309 earliest_still_active_fetch_start=2026-05-08T06:12:03.726935+00:00
[demo] client request thread finished
[demo] shutting down warcprox & upstream...
```