### PR TITLE
fix path traversal in certauth: validate cert path stays within certs…

### DIFF
--- a/warcprox/certauth.py
+++ b/warcprox/certauth.py
@@ -73,6 +73,11 @@ class CertificateAuthority:
     def cert_for_host(self, host, overwrite=False, wildcard=False):
         with self._lock:
             host_filename = os.path.join(self.certs_dir, host) + '.pem'
+            # Prevent path traversal: ensure resolved path stays inside certs_dir
+            # (os.path.join silently discards certs_dir when host is absolute)
+            if not os.path.realpath(host_filename).startswith(
+                    os.path.realpath(self.certs_dir) + os.sep):
+                raise ValueError('hostname would escape certs_dir: %r' % host)
 
             if not overwrite and os.path.exists(host_filename):
                 self._file_created = False


### PR DESCRIPTION
…_dir

os.path.join silently discards certs_dir when the hostname argument is absolute, allowing a CONNECT request with a path-like host to write a PEM file outside the intended directory. Guard against this by comparing os.path.realpath of the assembled path against os.path.realpath of certs_dir before any file I/O occurs.