### PR TITLE
Fix wildcard cert generation issuing invalid certs at public suffix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "idna",
   "PyYAML>=5.1",
   "cachetools",
+  "tldextract",
   "rfc3986>=1.5.0",
   # Needed because of rethinkdb 2.4.9;
   # can be removed once doublethink upgrades to 2.4.10.post1

--- a/tests/test_certauth.py
+++ b/tests/test_certauth.py
@@ -4,6 +4,8 @@ import shutil
 from warcprox.certauth import main, CertificateAuthority
 import tempfile
 from OpenSSL import crypto
+from cryptography import x509 as cryptography_x509
+from cryptography.hazmat.primitives.serialization import Encoding
 import datetime
 import time
 
@@ -40,10 +42,66 @@ def test_create_wildcard_host_cert_force_overwrite():
 def test_explicit_wildcard():
     ca = CertificateAuthority(TEST_CA_ROOT, TEST_CA_DIR, 'Test CA')
     filename = ca.get_wildcard_cert('test.example.proxy')
-    certfile = os.path.join(TEST_CA_DIR, 'example.proxy.pem')
+    certfile = os.path.join(TEST_CA_DIR, 'test.example.proxy.pem')
     assert filename == certfile
     assert os.path.isfile(certfile)
     os.remove(certfile)
+
+def _cert_cn(pem_path):
+    with open(pem_path, 'rb') as f:
+        cert = cryptography_x509.load_pem_x509_certificate(f.read())
+    return cert.subject.get_attributes_for_oid(cryptography_x509.NameOID.COMMON_NAME)[0].value
+
+def _cert_sans(pem_path):
+    with open(pem_path, 'rb') as f:
+        cert = cryptography_x509.load_pem_x509_certificate(f.read())
+    try:
+        san_ext = cert.extensions.get_extension_for_class(cryptography_x509.SubjectAlternativeName)
+        return san_ext.value.get_values_for_type(cryptography_x509.DNSName)
+    except cryptography_x509.ExtensionNotFound:
+        return []
+
+def test_wildcard_cert_tld_aware():
+    ca = CertificateAuthority(TEST_CA_ROOT, TEST_CA_DIR, 'Test CA')
+
+    f = ca.get_wildcard_cert('auspost.com.au')
+    assert f == os.path.join(TEST_CA_DIR, 'auspost.com.au.pem')
+    assert _cert_cn(f) == 'auspost.com.au'
+    assert '*.auspost.com.au' in _cert_sans(f)
+    assert '*.com.au' not in _cert_sans(f)
+    os.remove(f)
+
+    f = ca.get_wildcard_cert('www.auspost.com.au')
+    assert f == os.path.join(TEST_CA_DIR, 'auspost.com.au.pem')
+    assert _cert_cn(f) == 'auspost.com.au'
+    assert '*.auspost.com.au' in _cert_sans(f)
+    assert '*.com.au' not in _cert_sans(f)
+    os.remove(f)
+
+    f = ca.get_wildcard_cert('foo.example.com')
+    assert f == os.path.join(TEST_CA_DIR, 'example.com.pem')
+    assert _cert_cn(f) == 'example.com'
+    assert '*.example.com' in _cert_sans(f)
+    os.remove(f)
+
+    f = ca.get_wildcard_cert('a.b.example.com')
+    assert f == os.path.join(TEST_CA_DIR, 'b.example.com.pem')
+    assert _cert_cn(f) == 'b.example.com'
+    assert '*.b.example.com' in _cert_sans(f)
+    assert '*.example.com' not in _cert_sans(f)
+    os.remove(f)
+
+    # Don't remove; test_create_already_exists depends on it existing.
+    f = ca.get_wildcard_cert('example.com')
+    assert f == os.path.join(TEST_CA_DIR, 'example.com.pem')
+    assert _cert_cn(f) == 'example.com'
+
+    f = ca.get_wildcard_cert('foo.act.gov.au')
+    assert f == os.path.join(TEST_CA_DIR, 'act.gov.au.pem')
+    assert _cert_cn(f) == 'act.gov.au'
+    assert '*.act.gov.au' in _cert_sans(f)
+    assert '*.gov.au' not in _cert_sans(f)
+    os.remove(f)
 
 def test_create_already_exists():
     ret = main([TEST_CA_ROOT, '-d', TEST_CA_DIR, '-n', 'example.com', '-w'])

--- a/warcprox/certauth.py
+++ b/warcprox/certauth.py
@@ -5,6 +5,8 @@ import datetime
 from datetime import timedelta, timezone
 import threading
 
+import tldextract
+
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
@@ -85,9 +87,15 @@ class CertificateAuthority:
             return host_filename
 
     def get_wildcard_cert(self, cert_host):
-        host_parts = cert_host.split('.', 1)
-        if len(host_parts) == 2 and '.' in host_parts[1]:
-            cert_host = host_parts[1]
+        ext = tldextract.extract(cert_host)
+        registered_domain = ext.top_domain_under_public_suffix
+
+        if registered_domain and cert_host != registered_domain:
+            subdomain_labels = ext.subdomain.split('.')
+            if len(subdomain_labels) == 1:
+                cert_host = registered_domain
+            else:
+                cert_host = '.'.join(subdomain_labels[1:]) + '.' + registered_domain
 
         certfile = self.cert_for_host(cert_host,
                                       wildcard=True)


### PR DESCRIPTION
the original impl blindly stripe from the left, which from my personal archiver project when visiting `auspost.com.au` caused warcprox to produce wildcard cert for `com.au` which can be dangerous and chromium rejects it with ERR_CERT_COMMON_NAME_INVALID on my local test, this changes respect the PSL to avoid blindly issuing invalid wild cert