### PR TITLE
drop dead ssl.wrap_socket() fallback in _connect_to_remote_server

### DIFF
--- a/warcprox/mitmproxy.py
+++ b/warcprox/mitmproxy.py
@@ -1,7 +1,7 @@
 '''
 warcprox/mitmproxy.py - man-in-the-middle http/s proxy code, handles http
 CONNECT method by creating a snakeoil certificate for the requested site,
-calling ssl.wrap_socket() on the client connection; connects to remote
+wrapping the client connection with an SSLContext; connects to remote
 (proxied) host, possibly using tor if host tld is .onion and tor proxy is
 configured
 
@@ -303,17 +303,6 @@ class MitmProxyHandler(http_server.BaseHTTPRequestHandler):
                     self._remote_server_conn.sock = context.wrap_socket(
                             self._remote_server_conn.sock,
                             server_hostname=self.hostname)
-                except AttributeError:
-                    try:
-                        self._remote_server_conn.sock = ssl.wrap_socket(
-                                self._remote_server_conn.sock)
-                    except ssl.SSLError:
-                        self.logger.warning(
-                                "failed to establish ssl connection to %s; "
-                                "python ssl library does not support SNI, "
-                                "consider upgrading to python 2.7.9+ or 3.4+",
-                                self.hostname)
-                    raise
                 except ssl.SSLError as e:
                     self.logger.error(
                             'error connecting to %s (%s) port %s: %s',


### PR DESCRIPTION
The `except AttributeError` branch called `ssl.wrap_socket()`, which was deprecated in Python 3.6 and removed in Python 3.12. The branch was also unreachable in practice: `remote_connection_pool` is always constructed with `ssl_context=ssl_context` (see SingleThreadedMitmProxy.__init__), so the primary `context.wrap_socket()` call cannot raise AttributeError from a missing ssl_context. On top of that, the fallback's outer `raise` unconditionally re-raised the original AttributeError even after the inner assignment "succeeded", making the assignment useless. The warning message referred to Python 2.7.9+ / 3.4+, which is meaningless now that we require Python 3.9+.