### PR TITLE
Remove unused idna dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
   "requests>=2.0.1",
   "PySocks>=1.6.8",
   "cryptography>=45,<46",
-  "idna",
   "PyYAML>=5.1",
   "cachetools",
   "rfc3986>=1.5.0",


### PR DESCRIPTION
We never import `idna`. We only use `parsed_url.host.encode('idna')` once.
That uses Python's stdlib IDNA codec, not the `idna` dependency.

BTW, note that `idna` is a dependency of `requests`.